### PR TITLE
Initial TS-7990 support

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -472,6 +472,12 @@ dtb-$(CONFIG_SOC_IMX6Q) += \
 	imx6dl-ts4900-2.dtb \
 	imx6dl-ts4900-14.dtb \
 	imx6dl-ts7970.dtb \
+	imx6dl-ts7990-lxd-revb.dtb \
+	imx6dl-ts7990-lxd.dtb \
+	imx6dl-ts7990-microtips-revb.dtb \
+	imx6dl-ts7990-microtips.dtb \
+	imx6dl-ts7990-okaya-revb.dtb \
+	imx6dl-ts7990-okaya.dtb \
 	imx6dl-tx6dl-comtft.dtb \
 	imx6dl-tx6s-8034.dtb \
 	imx6dl-tx6s-8034-mb7.dtb \
@@ -567,6 +573,12 @@ dtb-$(CONFIG_SOC_IMX6Q) += \
 	imx6q-ts4900-2.dtb \
 	imx6q-ts4900-14.dtb \
 	imx6q-ts7970.dtb \
+	imx6q-ts7990-lxd-revb.dtb \
+	imx6q-ts7990-lxd.dtb \
+	imx6q-ts7990-microtips-revb.dtb \
+	imx6q-ts7990-microtips.dtb \
+	imx6q-ts7990-okaya-revb.dtb \
+	imx6q-ts7990-okaya.dtb \
 	imx6q-tx6q-1010.dtb \
 	imx6q-tx6q-1010-comtft.dtb \
 	imx6q-tx6q-1020.dtb \

--- a/arch/arm/boot/dts/imx6dl-ts7990-lxd-revb.dts
+++ b/arch/arm/boot/dts/imx6dl-ts7990-lxd-revb.dts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6dl.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Solo/DualLite TS-7990 (LXD) REV B";
+	compatible = "fsl,imx6dl-ts7990", "fsl,imx6dl";
+
+	lcd_lvds0: disp0 {
+		compatible = "panel-dpi";
+		backlight = <&backlight0>;
+
+		panel-timing {
+			clock-frequency = <51200000>;
+			hactive = <1024>;
+			vactive = <600>;
+			hback-porch = <46>;
+			hfront-porch = <210>;
+			vback-porch = <23>;
+			vfront-porch = <12>;
+			hsync-len = <20>;
+			vsync-len = <10>;
+			de-active = <1>;
+			hsync-active = <1>;
+			vsync-active = <1>;
+			pixelclk-active = <0>;
+		};
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&lvds0_out>;
+			};
+		};
+	};
+
+	wifi_spi: spi-gpio {
+		compatible = "spi-gpio";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ecspi5gpio>;
+		status = "okay";
+		num-chipselects = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		gpio-sck = <&gpio1 20 GPIO_ACTIVE_HIGH>;
+		gpio-mosi = <&gpio1 18 GPIO_ACTIVE_HIGH>;
+		gpio-miso = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+
+		wilc3000: wifi@0 {
+			compatible = "microchip,wilc3000";
+			reg = <0>;
+			spi-max-frequency = <18000000>;
+			reset-gpios = <&gpio8 13 GPIO_ACTIVE_HIGH>;
+			chip_en-gpios = <&gpio8 14 GPIO_ACTIVE_HIGH>;
+			interrupt-parent = <&gpio1>;
+			interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+		};
+	};
+};
+
+&pixcir_tangoc {
+	status = "okay";
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	imx6-ts7990 {
+		pinctrl_ecspi5gpio: ecspi5gpio {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_CMD__GPIO1_IO18		0x100b1 /* mosi */
+				MX6QDL_PAD_SD1_CLK__GPIO1_IO20		0x100b1 /* sclk */
+				MX6QDL_PAD_SD1_DAT0__GPIO1_IO16		0x100b1 /* miso */
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17		0x1b088 /* SPI_1_CS# */
+				MX6QDL_PAD_ENET_RXD1__GPIO1_IO26	0x1b088 /* WIFI_IRQ# */
+			>;
+		};
+	};
+};
+
+&ldb {
+	status = "okay";
+
+	lvds-channel@0 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <18>;
+
+		status = "okay";
+
+		port@4 {
+			reg = <4>;
+
+			lvds0_out: endpoint {
+				remote-endpoint = <&panel_in>;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/imx6dl-ts7990-lxd.dts
+++ b/arch/arm/boot/dts/imx6dl-ts7990-lxd.dts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6dl.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Solo/DualLite TS-7990 (LXD)";
+	compatible = "fsl,imx6dl-ts7990", "fsl,imx6dl";
+
+	lcd_lvds0: disp0 {
+		compatible = "panel-dpi";
+		backlight = <&backlight0>;
+
+		panel-timing {
+			clock-frequency = <51200000>;
+			hactive = <1024>;
+			vactive = <600>;
+			hback-porch = <46>;
+			hfront-porch = <210>;
+			vback-porch = <23>;
+			vfront-porch = <12>;
+			hsync-len = <20>;
+			vsync-len = <10>;
+			de-active = <1>;
+			hsync-active = <1>;
+			vsync-active = <1>;
+			pixelclk-active = <0>;
+		};
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&lvds0_out>;
+			};
+		};
+	};
+};
+
+&pixcir_tangoc {
+	status = "okay";
+};
+
+&ldb {
+	status = "okay";
+
+	lvds-channel@0 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <18>;
+
+		status = "okay";
+
+		port@4 {
+			reg = <4>;
+
+			lvds0_out: endpoint {
+				remote-endpoint = <&panel_in>;
+			};
+		};
+	};
+};
+
+&usdhc1 {
+	status = "okay";
+};
+
+&reg_wlan_vqmmc {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6dl-ts7990-microtips-revb.dts
+++ b/arch/arm/boot/dts/imx6dl-ts7990-microtips-revb.dts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6dl.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Solo/DualLite TS-7990 (Microtips)";
+	compatible = "fsl,imx6dl-ts7990", "fsl,imx6dl";
+
+	lcd_display: disp0 {
+		compatible = "fsl,imx-parallel-display";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ipu>;
+
+		display-timings {
+			MICROTIPS-WVGA {
+				clock-frequency = <30030000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <46>;
+				hback-porch = <210>;
+				hsync-len = <1>;
+				vback-porch = <22>;
+				vfront-porch = <23>;
+				vsync-len = <1>;
+
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+
+		port@0 {
+			lcd_display_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+	};
+
+	wifi_spi: spi-gpio {
+		compatible = "spi-gpio";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ecspi5gpio>;
+		status = "okay";
+		num-chipselects = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		gpio-sck = <&gpio1 20 GPIO_ACTIVE_HIGH>;
+		gpio-mosi = <&gpio1 18 GPIO_ACTIVE_HIGH>;
+		gpio-miso = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+
+		wilc3000: wifi@0 {
+			compatible = "microchip,wilc3000";
+			reg = <0>;
+			spi-max-frequency = <18000000>;
+			reset-gpios = <&gpio8 13 GPIO_ACTIVE_HIGH>;
+			chip_en-gpios = <&gpio8 14 GPIO_ACTIVE_HIGH>;
+			interrupt-parent = <&gpio1>;
+			interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+		};
+	};
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	imx6-ts7990 {
+		pinctrl_ecspi5gpio: ecspi5gpio {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_CMD__GPIO1_IO18		0x100b1 /* mosi */
+				MX6QDL_PAD_SD1_CLK__GPIO1_IO20		0x100b1 /* sclk */
+				MX6QDL_PAD_SD1_DAT0__GPIO1_IO16		0x100b1 /* miso */
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17		0x1b088 /* SPI_1_CS# */
+				MX6QDL_PAD_ENET_RXD1__GPIO1_IO26	0x1b088 /* WIFI_IRQ# */
+			>;
+		};
+	};
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&lcd_display_in>;
+};
+
+&touch_spi {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6dl-ts7990-microtips.dts
+++ b/arch/arm/boot/dts/imx6dl-ts7990-microtips.dts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6dl.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Solo/DualLite TS-7990 (Microtips)";
+	compatible = "fsl,imx6dl-ts7990", "fsl,imx6dl";
+
+	lcd_display: disp0 {
+		compatible = "fsl,imx-parallel-display";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ipu>;
+
+		display-timings {
+			MICROTIPS-WVGA {
+				clock-frequency = <30030000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <46>;
+				hback-porch = <210>;
+				hsync-len = <1>;
+				vback-porch = <22>;
+				vfront-porch = <23>;
+				vsync-len = <1>;
+
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+
+		port@0 {
+			lcd_display_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+	};
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&lcd_display_in>;
+};
+
+&touch_spi {
+	status = "okay";
+};
+
+&usdhc1 {
+	status = "okay";
+};
+
+&reg_wlan_vqmmc {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6dl-ts7990-okaya-revb.dts
+++ b/arch/arm/boot/dts/imx6dl-ts7990-okaya-revb.dts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6dl.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Solo/DualLite TS-7990 (Okaya)";
+	compatible = "fsl,imx6dl-ts7990", "fsl,imx6dl";
+
+	lcd_display: disp0 {
+		compatible = "fsl,imx-parallel-display";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ipu>;
+
+		display-timings {
+			OKAYA-WVGA {
+				clock-frequency = <30066000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <50>;
+				hback-porch = <70>;
+				hsync-len = <50>;
+				vback-porch = <2>;
+				vfront-porch = <2>;
+				vsync-len = <50>;
+
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+
+		port@0 {
+			lcd_display_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+	};
+
+	wifi_spi: spi-gpio {
+		compatible = "spi-gpio";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ecspi5gpio>;
+		status = "okay";
+		num-chipselects = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		gpio-sck = <&gpio1 20 GPIO_ACTIVE_HIGH>;
+		gpio-mosi = <&gpio1 18 GPIO_ACTIVE_HIGH>;
+		gpio-miso = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+
+		wilc3000: wifi@0 {
+			compatible = "microchip,wilc3000";
+			reg = <0>;
+			spi-max-frequency = <18000000>;
+			reset-gpios = <&gpio8 13 GPIO_ACTIVE_HIGH>;
+			chip_en-gpios = <&gpio8 14 GPIO_ACTIVE_HIGH>;
+			interrupt-parent = <&gpio1>;
+			interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+		};
+	};
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	imx6-ts7990 {
+		pinctrl_ecspi5gpio: ecspi5gpio {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_CMD__GPIO1_IO18		0x100b1 /* mosi */
+				MX6QDL_PAD_SD1_CLK__GPIO1_IO20		0x100b1 /* sclk */
+				MX6QDL_PAD_SD1_DAT0__GPIO1_IO16		0x100b1 /* miso */
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17		0x1b088 /* SPI_1_CS# */
+				MX6QDL_PAD_ENET_RXD1__GPIO1_IO26	0x1b088 /* WIFI_IRQ# */
+			>;
+		};
+	};
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&lcd_display_in>;
+};
+
+&touch_spi {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6dl-ts7990-okaya.dts
+++ b/arch/arm/boot/dts/imx6dl-ts7990-okaya.dts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6dl.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Solo/DualLite TS-7990 (Okaya)";
+	compatible = "fsl,imx6dl-ts7990", "fsl,imx6dl";
+
+	lcd_display: disp0 {
+		compatible = "fsl,imx-parallel-display";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ipu>;
+
+		display-timings {
+			OKAYA-WVGA {
+				clock-frequency = <30066000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <50>;
+				hback-porch = <70>;
+				hsync-len = <50>;
+				vback-porch = <2>;
+				vfront-porch = <2>;
+				vsync-len = <50>;
+
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+
+		port@0 {
+			lcd_display_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+	};
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&lcd_display_in>;
+};
+
+&touch_spi {
+	status = "okay";
+};
+
+&usdhc1 {
+	status = "okay";
+};
+
+&reg_wlan_vqmmc {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6q-ts7990-lxd-revb.dts
+++ b/arch/arm/boot/dts/imx6q-ts7990-lxd-revb.dts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6q.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Quad TS-7990 (LXD) REV B";
+	compatible = "fsl,imx6q-ts7990", "fsl,imx6q";
+
+	lcd_lvds0: disp0 {
+		compatible = "panel-dpi";
+		backlight = <&backlight0>;
+
+		panel-timing {
+			clock-frequency = <51200000>;
+			hactive = <1024>;
+			vactive = <600>;
+			hback-porch = <46>;
+			hfront-porch = <210>;
+			vback-porch = <23>;
+			vfront-porch = <12>;
+			hsync-len = <20>;
+			vsync-len = <10>;
+			de-active = <1>;
+			hsync-active = <1>;
+			vsync-active = <1>;
+			pixelclk-active = <0>;
+		};
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&lvds0_out>;
+			};
+		};
+	};
+};
+
+&pixcir_tangoc {
+	status = "okay";
+};
+
+&ecspi5 {
+	num-cs = <1>;
+	cs-gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ecspi5>;
+	status = "okay";
+
+	wilc3000: wifi@0 {
+		compatible = "microchip,wilc3000";
+		reg = <0>;
+		spi-max-frequency = <18000000>;
+		reset-gpios = <&gpio8 13 GPIO_ACTIVE_HIGH>;
+		chip_en-gpios = <&gpio8 14 GPIO_ACTIVE_HIGH>;
+		interrupt-parent = <&gpio1>;
+		interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+	};
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	imx6-ts7990 {
+		pinctrl_ecspi5: ecspi5 {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_CMD__ECSPI5_MOSI		0x1b0b0
+				MX6QDL_PAD_SD1_CLK__ECSPI5_SCLK		0x1b0b0
+				MX6QDL_PAD_SD1_DAT0__ECSPI5_MISO	0x1b0b0
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17		0x1b088 /* SPI_1_CS# */
+				MX6QDL_PAD_ENET_RXD1__GPIO1_IO26	0x1b088 /* WIFI_IRQ# */
+			>;
+		};
+	};
+};
+
+&ldb {
+	status = "okay";
+
+	lvds-channel@0 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <18>;
+
+		status = "okay";
+
+		port@4 {
+			reg = <4>;
+
+			lvds0_out: endpoint {
+				remote-endpoint = <&panel_in>;
+			};
+		};
+	};
+};
+
+&sata {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6q-ts7990-lxd.dts
+++ b/arch/arm/boot/dts/imx6q-ts7990-lxd.dts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6q.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Quad TS-7990 (LXD)";
+	compatible = "fsl,imx6q-ts7990", "fsl,imx6q";
+
+	lcd_lvds0: disp0 {
+		compatible = "panel-dpi";
+		backlight = <&backlight0>;
+
+		panel-timing {
+			clock-frequency = <51200000>;
+			hactive = <1024>;
+			vactive = <600>;
+			hback-porch = <46>;
+			hfront-porch = <210>;
+			vback-porch = <23>;
+			vfront-porch = <12>;
+			hsync-len = <20>;
+			vsync-len = <10>;
+			de-active = <1>;
+			hsync-active = <1>;
+			vsync-active = <1>;
+			pixelclk-active = <0>;
+		};
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&lvds0_out>;
+			};
+		};
+	};
+};
+
+&pixcir_tangoc {
+	status = "okay";
+};
+
+&ldb {
+	status = "okay";
+
+	lvds-channel@0 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <18>;
+
+		status = "okay";
+
+		port@4 {
+			reg = <4>;
+
+			lvds0_out: endpoint {
+				remote-endpoint = <&panel_in>;
+			};
+		};
+	};
+};
+
+&sata {
+	status = "okay";
+};
+
+&usdhc1 {
+	status = "okay";
+};
+
+&reg_wlan_vqmmc {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6q-ts7990-microtips-revb.dts
+++ b/arch/arm/boot/dts/imx6q-ts7990-microtips-revb.dts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6q.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Quad TS-7990 (Microtips)";
+	compatible = "fsl,imx6q-ts7990", "fsl,imx6q";
+
+	lcd_display: disp0 {
+		compatible = "fsl,imx-parallel-display";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ipu>;
+
+		display-timings {
+			MICROTIPS-WVGA {
+				clock-frequency = <30030000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <46>;
+				hback-porch = <210>;
+				hsync-len = <1>;
+				vback-porch = <22>;
+				vfront-porch = <23>;
+				vsync-len = <1>;
+
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+
+		port@0 {
+			lcd_display_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+	};
+};
+
+&ecspi5 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ecspi5>;
+	num-cs = <1>;
+	cs-gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	wilc3000: wifi@0 {
+		compatible = "microchip,wilc3000";
+		reg = <0>;
+		spi-max-frequency = <18000000>;
+		reset-gpios = <&gpio8 13 GPIO_ACTIVE_HIGH>;
+		chip_en-gpios = <&gpio8 14 GPIO_ACTIVE_HIGH>;
+		interrupt-parent = <&gpio1>;
+		interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+	};
+};
+
+&iomuxc {
+	imx6-ts7990 {
+		pinctrl_ecspi5: ecspi5grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_CMD__ECSPI5_MOSI		0x100b1
+				MX6QDL_PAD_SD1_CLK__ECSPI5_SCLK		0x100b1
+				MX6QDL_PAD_SD1_DAT0__ECSPI5_MISO	0x100b1
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17		0x1b088 /* SPI_1_CS# */
+				MX6QDL_PAD_ENET_RXD1__GPIO1_IO26	0x1b088 /* WIFI_IRQ# */
+				/* XXX: Add chip-en and reset GPIOS */
+			>;
+		};
+	};
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&lcd_display_in>;
+};
+
+&sata {
+	status = "okay";
+};
+
+&touch_spi {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6q-ts7990-microtips.dts
+++ b/arch/arm/boot/dts/imx6q-ts7990-microtips.dts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6q.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Quad TS-7990 (Microtips)";
+	compatible = "fsl,imx6q-ts7990", "fsl,imx6q";
+
+	lcd_display: disp0 {
+		compatible = "fsl,imx-parallel-display";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ipu>;
+
+		display-timings {
+			MICROTIPS-WVGA {
+				clock-frequency = <30030000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <46>;
+				hback-porch = <210>;
+				hsync-len = <1>;
+				vback-porch = <22>;
+				vfront-porch = <23>;
+				vsync-len = <1>;
+
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+
+		port@0 {
+			lcd_display_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+	};
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&lcd_display_in>;
+};
+
+&sata {
+	status = "okay";
+};
+
+&touch_spi {
+	status = "okay";
+};
+
+&usdhc1 {
+	status = "okay";
+};
+
+&reg_wlan_vqmmc {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6q-ts7990-okaya-revb.dts
+++ b/arch/arm/boot/dts/imx6q-ts7990-okaya-revb.dts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6q.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Quad TS-7990 (Okaya)";
+	compatible = "fsl,imx6q-ts7990", "fsl,imx6q";
+
+	lcd_display: disp0 {
+		compatible = "fsl,imx-parallel-display";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ipu>;
+
+		display-timings {
+			OKAYA-WVGA {
+				clock-frequency = <30066000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <50>;
+				hback-porch = <70>;
+				hsync-len = <50>;
+				vback-porch = <2>;
+				vfront-porch = <2>;
+				vsync-len = <50>;
+
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+
+		port@0 {
+			lcd_display_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+	};
+};
+
+&ecspi5 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ecspi5>;
+	num-cs = <1>;
+	cs-gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	wilc3000: wifi@0 {
+		compatible = "microchip,wilc3000";
+		reg = <0>;
+		spi-max-frequency = <18000000>;
+		reset-gpios = <&gpio8 13 GPIO_ACTIVE_HIGH>;
+		chip_en-gpios = <&gpio8 14 GPIO_ACTIVE_HIGH>;
+		interrupt-parent = <&gpio1>;
+		interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+	};
+};
+
+&iomuxc {
+	imx6-ts7990 {
+		pinctrl_ecspi5: ecspi5grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_CMD__ECSPI5_MOSI		0x100b1
+				MX6QDL_PAD_SD1_CLK__ECSPI5_SCLK		0x100b1
+				MX6QDL_PAD_SD1_DAT0__ECSPI5_MISO	0x100b1
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17		0x1b088 /* SPI_1_CS# */
+				MX6QDL_PAD_ENET_RXD1__GPIO1_IO26	0x1b088 /* WIFI_IRQ# */
+				/* XXX: Add chip-en and reset GPIOS */
+			>;
+		};
+	};
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&lcd_display_in>;
+};
+
+&sata {
+	status = "okay";
+};
+
+&touch_spi {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6q-ts7990-okaya.dts
+++ b/arch/arm/boot/dts/imx6q-ts7990-okaya.dts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+/dts-v1/;
+#include "imx6q.dtsi"
+#include "imx6qdl-ts7990.dtsi"
+
+/ {
+	model = "embeddedTS i.MX6 Quad TS-7990 (Okaya)";
+	compatible = "fsl,imx6q-ts7990", "fsl,imx6q";
+
+	lcd_display: disp0 {
+		compatible = "fsl,imx-parallel-display";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ipu>;
+
+		display-timings {
+			OKAYA-WVGA {
+				clock-frequency = <30066000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <50>;
+				hback-porch = <70>;
+				hsync-len = <50>;
+				vback-porch = <2>;
+				vfront-porch = <2>;
+				vsync-len = <50>;
+
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+
+		port@0 {
+			lcd_display_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+	};
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&lcd_display_in>;
+};
+
+&sata {
+	status = "okay";
+};
+
+&touch_spi {
+	status = "okay";
+};
+
+&usdhc1 {
+	status = "okay";
+};
+
+&reg_wlan_vqmmc {
+	status = "okay";
+};

--- a/arch/arm/boot/dts/imx6qdl-ts7990.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-ts7990.dtsi
@@ -1,0 +1,724 @@
+// SPDX-License-Identifier: GPL-2.0 OR X11
+/*
+ * Copyright 2017-2022 Technologic Systems, Inc. dba embeddedTS
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	chosen {
+		stdout-path = &uart1;
+	};
+
+	aliases {
+		ethernet0 = &fec;
+	};
+
+	backlight0: backlight {
+		compatible = "pwm-backlight";
+		power-supply = <&reg_backlight>;
+		pwms = <&pwm3 0 5000000 0>;
+		brightness-levels = <0 100>;
+		num-interpolated-steps = <100>;
+		default-brightness-level = <100>;
+	};
+
+	led-controller {
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_leds1>;
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio5 21 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_INDICATOR;
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+
+	reg_backlight: regulator-backlight {
+		compatible = "regulator-fixed";
+		regulator-name = "BACKLIGHT_LCD";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_bkl>;
+		regulator-min-microvolt = <28000000>;
+		regulator-max-microvolt = <28000000>;
+		startup-delay-us = <2000>;
+		gpio = <&gpio3 0 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	reg_1v2: regulator-1v2 {
+		compatible = "regulator-fixed";
+		regulator-name = "1V2";
+		regulator-min-microvolt = <1200000>;
+		regulator-max-microvolt = <1200000>;
+		regulator-always-on;
+	};
+
+	reg_3v3: regulator-3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "3V3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	reg_can_3v3: regulator-can-en {
+		compatible = "regulator-fixed";
+		regulator-name = "CAN_EN";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio6 31 GPIO_ACTIVE_HIGH>;
+	};
+
+	reg_usb_otg_vbus: regulator-usb-otg-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "USB_OTG_VBUS";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio3 22 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	reg_wlan_vqmmc: regulator-wlan-vqmmc {
+		compatible = "regulator-fixed";
+		regulator-name = "WLAN_1V8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		gpio = <&gpio8 14 GPIO_ACTIVE_HIGH>;
+		startup-delay-us = <100000>;
+		enable-active-high;
+		status = "disabled";
+	};
+
+	sound {
+		audio-codec = <&sgtl5000>;
+		audio-routing =
+			"MIC_IN", "Mic Jack",
+			"Mic Jack", "Mic Bias",
+			"Headphone Jack", "HP_OUT";
+		compatible = "fsl,imx-audio-sgtl5000";
+		model = "On-board Codec";
+		mux-ext-port = <3>;
+		mux-int-port = <1>;
+		ssi-controller = <&ssi1>;
+	};
+
+	touch_spi: spi {
+		compatible = "spi-gpio";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_touch_spi>;
+		gpio-sck = <&gpio2 20 GPIO_ACTIVE_HIGH>;
+		gpio-mosi = <&gpio2 18 GPIO_ACTIVE_HIGH>;
+		gpio-miso = <&gpio2 17 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio2 19 GPIO_ACTIVE_LOW>;
+		num-chipselects = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+
+		tsc2046: touchscreen@0 {
+			compatible = "ti,tsc2046";
+			reg = <0>;
+			/* Interrupt configured by GPIO hog, shared with cap touch */
+			interrupt-parent = <&gpio3>;
+			interrupts = <12 IRQ_TYPE_EDGE_FALLING>;
+			vcc-supply = <&reg_3v3>;
+			spi-max-frequency = <100000>;
+			pendown-gpio = <&gpio3 12 0>;
+			ti,penirq-recheck-delay-usecs = /bits/ 16 <5000>;
+			ti,vref-mv = <3300>;
+			ti,swap-xy;
+			ti,keep-vref-on;
+			ti,settle-delay-usec = /bits/ 16 <5000>;
+			ti,vref-delay-usecs = /bits/ 16 <0>;
+			ti,x-plate-ohms = /bits/ 16 <400>;
+			ti,y-plate-ohms = /bits/ 16 <400>;
+			ti,debounce-rep = /bits/ 16 <2>;
+			ti,debounce-tol = /bits/ 16 <65535>;
+			ti,debounce-max = /bits/ 16 <0>;
+			ti,pressure-max = /bits/ 16 <15000>;
+			ti,pendown-gpio-debounce = <10000>;
+			linux,wakeup;
+		};
+	};
+};
+
+&audmux {
+	status = "okay";
+};
+
+&can1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_flexcan1>;
+	xceiver-supply = <&reg_can_3v3>;
+	status = "okay";
+};
+
+&can2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_flexcan2>;
+	xceiver-supply = <&reg_can_3v3>;
+	status = "okay";
+};
+
+
+&ecspi1 {
+	fsl,spi-num-chipselects = <1>;
+	cs-gpios = <&gpio3 19 GPIO_ACTIVE_LOW>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ecspi1>;
+	status = "okay";
+
+	spiboot: flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <20000000>;
+		reg = <0>;
+	};
+};
+
+&ecspi2 {
+	num-cs = <3>;
+	cs-gpios = <
+		&gpio5 31 GPIO_ACTIVE_LOW
+		&gpio1 6 GPIO_ACTIVE_LOW
+		&gpio8 7 GPIO_ACTIVE_LOW
+	>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ecspi2>;
+	status = "okay";
+
+	max3100ts: serial@0 {
+		compatible = "technologic,max3100-ts";
+		reg = <0>;
+		interrupt-parent = <&gpio5>;
+		interrupts = <20 IRQ_TYPE_LEVEL_LOW>;
+		spi-max-frequency = <10000000>;
+		loopback = <0>;
+		crystal = <1>;
+		poll-time = <100>;
+	};
+
+	spidevfpga: spidev@1 {
+		compatible = "spidev";
+		reg = <1>;
+		spi-max-frequency = <1000000>;
+	};
+
+	spidevdc1: spidev@2 {
+		compatible = "spidev";
+		reg = <2>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&fec {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_enet>;
+	phy-mode = "rgmii";
+	status = "okay";
+};
+
+&gpio1 {
+	gpio-line-names = "", "", "", "", "", "", "", "", "", "TOUCH_RESET",
+		"", "", "", "", "", "", "", "", "", "", "", "",
+		"", "", "", "", "", "", "", "", "";
+};
+
+&gpio2 {
+	gpio-line-names = "", "", "", "", "PCIE_RESET#", "", "", "", "", "", "",
+		"USB_HUB_RESET#", "", "", "", "", "", "", "", "", "", "",
+		"EN_USB_5V", "", "", "JP_OPTION#", "JP_SD_BOOT#", "", "",
+		"EN_800_NIT";
+};
+
+&gpio3 {
+	gpio-line-names = "", "", "", "", "5V_REG_PWM_MODE", "EN_HUB_3.3V", "",
+		"", "", "PUSH_SW_1#", "PUSH_SW_2#", "POE_DETECT#", "", "", "",
+		"", "", "", "", "", "", "", "", "EN_EMMC_3.3V#";
+};
+
+&gpio4 {
+	gpio-line-names = "", "", "", "", "", "", "", "", "", "", "", "", "",
+		"", "", "", "", "", "EN_232_TRANS";
+};
+
+&gpio5 {
+	gpio-line-names = "", "", "", "", "", "", "", "", "", "", "", "", "",
+		"", "", "", "", "", "EN_NIM_USB#", "", "", "", "", "", "", "",
+		"", "", "", "", "NIM_PWR_ON";
+};
+
+&i2c1 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c1>;
+
+	pixcir_tangoc: touchscreen@5c {
+		compatible = "pixcir,pixcir_tangoc";
+		reg = <0x5c>;
+		/* Interrupt configured by GPIO hog, shared with res touch */
+		interrupt-parent = <&gpio3>;
+		interrupts = <12 IRQ_TYPE_LEVEL_LOW>;
+		attb-gpio = <&gpio3 12 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		touchscreen-size-x = <1024>;
+		touchscreen-size-y = <600>;
+		/*
+		 * The actual interrupt pin logic is inverted from touchscreen
+		 * INT output pin on the TS-TPC-7990. Indicate that we want the
+		 * touchscreen to drive active high, but the CPU interrupt will
+		 * actually be active low.
+		 */
+		invert-int-output;
+		wakeup-source;
+		status = "disabled";
+	};
+
+	m41t00s: rtc@68 {
+		compatible = "m41t00";
+		reg = <0x68>;
+	};
+
+	sgtl5000: audio-codec@a {
+		compatible = "fsl,sgtl5000";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_sgtl5000>;
+		reg = <0x0a>;
+		clocks = <&clks 201>;
+		VDDA-supply = <&reg_3v3>;
+		VDDIO-supply = <&reg_3v3>;
+		VDDD-supply = <&reg_1v2>;
+	};
+
+        mma8451: accelerometer@1c {
+		compatible = "fsl,mma8451";
+		reg = <0x1c>;
+		vdd-supply = <&reg_3v3>;
+		vddio-supply = <&reg_3v3>;
+		interrupt-parent = <&gpio2>;
+		interrupts = <23 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-names = "INT1";
+		/* INT2 is connected to CPU but is unused */
+	};
+
+	gpio8: gpio@28 {
+		compatible = "technologic,ts7970-gpio";
+		reg = <0x28>;
+		#gpio-cells = <2>;
+		gpio-controller;
+		ngpios = <64>;
+		base = <224>;
+
+		gpio-line-names = "", "", "", "", "", "", "DIO_8", "DIO_9", "",
+			"", "", "", "", "BT_EN", "WL_EN", "", "", "", "", "",
+			"DIO_1_SEL0", "DIO_2_SEL1", "DIO_3_SEL2", "DIO_4_PWM",
+			"DIO_5_SILAB_DATA", "DIO_6_POWER_FAIL", "DIO_7", "IRQ1",
+			"", "", "REBOOT", "", "", "", "", "", "", "", "", "",
+			"", "", "", "", "TTYMAX0_RXD", "TTYMAX1_RXD",
+			"TTYMAX2_RXD", "TXEN3_485", "COM1_TXD", "COM2_TXD",
+			"COM3_TXD", "", "COM1_RTS", "TTYMAX0_CTS",
+			"TTYMAX1_CTS", "TTYMAX2_CTS", "", "", "", "",
+			"MT_LCD_PRESENT", "EN_SPKR";
+
+		en-spkr-hog {
+			gpio-hog;
+			gpios = <61 GPIO_ACTIVE_HIGH>;
+			line-name = "EN_SPKR";
+			output-high;
+		};
+	};
+};
+
+&i2c2 {
+	status = "okay";
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_i2c2>;
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_hog>;
+
+	imx6-ts7990 {
+		pinctrl_ecspi1: ecspi1grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D17__ECSPI1_MISO		0x100b1
+				MX6QDL_PAD_EIM_D18__ECSPI1_MOSI		0x100b1
+				MX6QDL_PAD_EIM_D16__ECSPI1_SCLK		0x100b1
+				MX6QDL_PAD_EIM_D19__GPIO3_IO19		0x100b1 /* Onboard flash CS1# */
+			>;
+		};
+
+		pinctrl_ecspi2: ecspi2grp {
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT8__ECSPI2_SCLK	0x100b1 /* FPGA_SPI_CLK */
+				MX6QDL_PAD_CSI0_DAT9__ECSPI2_MOSI	0x100b1 /* FPGA_SPI_MOSI */
+				MX6QDL_PAD_CSI0_DAT10__ECSPI2_MISO	0x100b1 /* FPGA_SPI_MISO */
+				MX6QDL_PAD_CSI0_DAT13__GPIO5_IO31	0x1b088 /* FPGA_SPI_CS0# */
+				MX6QDL_PAD_CSI0_DATA_EN__GPIO5_IO20	0x1b088 /* FPGA_IRQ_0 */
+				MX6QDL_PAD_GPIO_4__GPIO1_IO04		0x1b088 /* FPGA_IRQ_1 */
+				MX6QDL_PAD_EIM_EB0__GPIO2_IO28		0x1b088 /* FPGA_IRQ_2 */
+				MX6QDL_PAD_GPIO_6__GPIO1_IO06		0x1b088 /* FPGA_SPI_CS1# */
+			>;
+		};
+
+		pinctrl_pwm3: pwm3grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD4_DAT1__PWM3_OUT		0x1b088
+			>;
+		};
+
+		pinctrl_enet: enetgrp {
+			fsl,pins = <
+				MX6QDL_PAD_ENET_MDIO__ENET_MDIO		0x1b0b0
+				MX6QDL_PAD_ENET_MDC__ENET_MDC		0x1b0b0
+				MX6QDL_PAD_RGMII_TXC__RGMII_TXC		0x1b0b0
+				MX6QDL_PAD_RGMII_TD0__RGMII_TD0		0x1b0b0
+				MX6QDL_PAD_RGMII_TD1__RGMII_TD1		0x1b0b0
+				MX6QDL_PAD_RGMII_TD2__RGMII_TD2		0x1b0b0
+				MX6QDL_PAD_RGMII_TD3__RGMII_TD3		0x1b0b0
+				MX6QDL_PAD_RGMII_TX_CTL__RGMII_TX_CTL	0x1b0b0
+				MX6QDL_PAD_RGMII_RXC__RGMII_RXC		0x1b0b0
+				MX6QDL_PAD_RGMII_RD0__RGMII_RD0		0x1b0b0
+				MX6QDL_PAD_RGMII_RD1__RGMII_RD1		0x1b0b0
+				MX6QDL_PAD_RGMII_RD2__RGMII_RD2		0x1b0b0
+				MX6QDL_PAD_RGMII_RD3__RGMII_RD3		0x1b0b0
+				MX6QDL_PAD_RGMII_RX_CTL__RGMII_RX_CTL	0x1b0b0
+				MX6QDL_PAD_ENET_REF_CLK__ENET_TX_CLK	0x1b0b0
+				MX6QDL_PAD_ENET_TX_EN__GPIO1_IO28	0x1b088
+				MX6QDL_PAD_DI0_PIN4__GPIO4_IO20		0x1b088 /* ETH_PHY_RESET */
+			>;
+		};
+
+		pinctrl_bkl: bklreggrp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_DA0__GPIO3_IO00		0x1b088
+			>;
+		};
+
+		pinctrl_flexcan1: flexcan1grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_ROW2__FLEXCAN1_RX	0x1b088
+				MX6QDL_PAD_KEY_COL2__FLEXCAN1_TX	0x1b088
+				MX6QDL_PAD_EIM_BCLK__GPIO6_IO31		0x1b088 /* EN_CAN# */
+			>;
+		};
+
+		pinctrl_flexcan2: flexcan2grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL4__FLEXCAN2_TX	0x1b088
+				MX6QDL_PAD_KEY_ROW4__FLEXCAN2_RX	0x1b088
+			>;
+		};
+
+		pinctrl_ipu: tsipugrp {
+			fsl,pins = <
+				MX6QDL_PAD_DI0_DISP_CLK__IPU1_DI0_DISP_CLK	0x38 /* LCD_PIX_CLK */
+				MX6QDL_PAD_DI0_PIN15__IPU1_DI0_PIN15		0xf0 /* LCD_DE */
+				MX6QDL_PAD_DISP0_DAT2__IPU1_DISP0_DATA02	0xe0 /* LCD_D02 */
+				MX6QDL_PAD_DISP0_DAT3__IPU1_DISP0_DATA03	0xe0 /* LCD_D03 */
+				MX6QDL_PAD_DISP0_DAT4__IPU1_DISP0_DATA04	0xe0 /* LCD_D04 */
+				MX6QDL_PAD_DISP0_DAT5__IPU1_DISP0_DATA05	0xe0 /* LCD_D05 */
+				MX6QDL_PAD_DISP0_DAT6__IPU1_DISP0_DATA06	0xe0 /* LCD_D06 */
+				MX6QDL_PAD_DISP0_DAT7__IPU1_DISP0_DATA07	0xe0 /* LCD_D07 */
+				MX6QDL_PAD_DISP0_DAT10__IPU1_DISP0_DATA10	0xe0 /* LCD_D10 */
+				MX6QDL_PAD_DISP0_DAT11__IPU1_DISP0_DATA11	0xe0 /* LCD_D11 */
+				MX6QDL_PAD_DISP0_DAT12__IPU1_DISP0_DATA12	0xe0 /* LCD_D12 */
+				MX6QDL_PAD_DISP0_DAT13__IPU1_DISP0_DATA13	0xe0 /* LCD_D13 */
+				MX6QDL_PAD_DISP0_DAT14__IPU1_DISP0_DATA14	0xe0 /* LCD_D14 */
+				MX6QDL_PAD_DISP0_DAT15__IPU1_DISP0_DATA15	0xe0 /* LCD_D15 */
+				MX6QDL_PAD_DISP0_DAT18__IPU1_DISP0_DATA18	0xe0 /* LCD_D18 */
+				MX6QDL_PAD_DISP0_DAT19__IPU1_DISP0_DATA19	0xe0 /* LCD_D19 */
+				MX6QDL_PAD_DISP0_DAT20__IPU1_DISP0_DATA20	0xe0 /* LCD_D20 */
+				MX6QDL_PAD_DISP0_DAT21__IPU1_DISP0_DATA21	0xe0 /* LCD_D21 */
+				MX6QDL_PAD_DISP0_DAT22__IPU1_DISP0_DATA22	0xe0 /* LCD_D22 */
+				MX6QDL_PAD_DISP0_DAT23__IPU1_DISP0_DATA23	0xe0 /* LCD_D23 */
+			>;
+		};
+
+		pinctrl_i2c1: i2c1grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D21__I2C1_SCL		0x4001b8b1
+				MX6QDL_PAD_EIM_D28__I2C1_SDA		0x4001b8b1
+				MX6QDL_PAD_EIM_CS0__GPIO2_IO23		0x17059 /* ACCEL_INT */
+				MX6QDL_PAD_EIM_DA15__GPIO3_IO15		0x17059 /* ACCEL_2_INT */
+				MX6QDL_PAD_GPIO_9__GPIO1_IO09		0x88 /* TOUCH_RESET */
+			>;
+		};
+
+		pinctrl_i2c1_gpio: i2c1gpiogrp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D21__GPIO3_IO21		0x4001b8b1
+				MX6QDL_PAD_EIM_D28__GPIO3_IO28		0x4001b8b1
+			>;
+		};
+
+		pinctrl_i2c2: i2c2grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL3__I2C2_SCL		0x4001b8b1
+				MX6QDL_PAD_KEY_ROW3__I2C2_SDA		0x4001b8b1
+			>;
+		};
+
+		pinctrl_i2c2_gpio: i2c2gpiogrp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL3__GPIO4_IO12		0x4001b8b1
+				MX6QDL_PAD_KEY_ROW3__GPIO4_IO13		0x4001b8b1
+			>;
+		};
+
+		pinctrl_uart1: uart1grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD3_DAT7__UART1_TX_DATA	0x1b088
+				MX6QDL_PAD_SD3_DAT6__UART1_RX_DATA	0x1b088
+			>;
+		};
+
+		pinctrl_uart2: uart2grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_7__UART2_TX_DATA	0x1b088
+				MX6QDL_PAD_GPIO_8__UART2_RX_DATA	0x1b088
+				MX6QDL_PAD_SD4_DAT6__UART2_CTS_B	0x1b088
+				MX6QDL_PAD_SD4_DAT5__UART2_RTS_B	0x1b088
+			>;
+		};
+
+		pinctrl_uart3: uart3grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D24__UART3_TX_DATA	0x1b088
+				MX6QDL_PAD_EIM_D25__UART3_RX_DATA	0x1b088
+				MX6QDL_PAD_EIM_D30__UART3_RTS_B		0x1b088
+				MX6QDL_PAD_EIM_D31__UART3_CTS_B		0x1b088
+			>;
+		};
+
+		pinctrl_uart4: uart4grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL0__UART4_TX_DATA	0x1b088
+				MX6QDL_PAD_KEY_ROW0__UART4_RX_DATA	0x1b088
+			>;
+		};
+
+		pinctrl_uart5: uart5grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL1__UART5_TX_DATA	0x1b088
+				MX6QDL_PAD_KEY_ROW1__UART5_RX_DATA	0x1b088
+			>;
+		};
+
+		pinctrl_usbotg: usbotggrp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_1__USB_OTG_ID		0x17059
+			>;
+		};
+
+		pinctrl_usdhc1: usdhc1grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_CMD__SD1_CMD		0x17059
+				MX6QDL_PAD_SD1_CLK__SD1_CLK		0x10059
+				MX6QDL_PAD_SD1_DAT0__SD1_DATA0		0x17059
+				MX6QDL_PAD_SD1_DAT1__SD1_DATA1		0x17059
+				MX6QDL_PAD_SD1_DAT2__SD1_DATA2		0x17059
+				MX6QDL_PAD_SD1_DAT3__SD1_DATA3		0x17059
+				MX6QDL_PAD_ENET_RXD1__GPIO1_IO26	0x1f0d9 /* WIFI IRQ */
+			>;
+		};
+
+		pinctrl_usdhc2: usdhc2grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD2_CMD__SD2_CMD		0x17059
+				MX6QDL_PAD_SD2_CLK__SD2_CLK		0x10059
+				MX6QDL_PAD_SD2_DAT0__SD2_DATA0		0x17059
+				MX6QDL_PAD_SD2_DAT1__SD2_DATA1		0x17059
+				MX6QDL_PAD_SD2_DAT2__SD2_DATA2		0x17059
+				MX6QDL_PAD_SD2_DAT3__SD2_DATA3		0x17059
+			>;
+		};
+
+		pinctrl_usdhc3: usdhc3grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD3_CMD__SD3_CMD		0x17059
+				MX6QDL_PAD_SD3_CLK__SD3_CLK		0x10059
+				MX6QDL_PAD_SD3_DAT0__SD3_DATA0		0x17059
+				MX6QDL_PAD_SD3_DAT1__SD3_DATA1		0x17059
+				MX6QDL_PAD_SD3_DAT2__SD3_DATA2		0x17059
+				MX6QDL_PAD_SD3_DAT3__SD3_DATA3		0x17059
+				MX6QDL_PAD_EIM_D23__GPIO3_IO23		0x88	/* EN_EMMC_3.3V# */
+			>;
+		};
+
+		pinctrl_leds1: leds1grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_2__GPIO1_IO02		0x1b088 /* RED_LED# */
+				MX6QDL_PAD_CSI0_VSYNC__GPIO5_IO21	0x1b088 /* GREEN_LED# */
+			>;
+		};
+
+		pinctrl_pcie: pciegrp {
+			fsl,pins = <
+				MX6QDL_PAD_NANDF_D4__GPIO2_IO04		0x1b088 /* PCIE_RESET# */
+			>;
+		};
+
+		pinctrl_sgtl5000: sgtl5000grp {
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT7__AUD3_RXD		0x130b0
+				MX6QDL_PAD_CSI0_DAT4__AUD3_TXC		0x130b0
+				MX6QDL_PAD_CSI0_DAT5__AUD3_TXD		0x110b0
+				MX6QDL_PAD_CSI0_DAT6__AUD3_TXFS		0x130b0
+				MX6QDL_PAD_GPIO_0__CCM_CLKO1		0x130b0 /* Audio CLK */
+			>;
+		};
+
+		pinctrl_touch_spi: touchspigrp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_A18__GPIO2_IO20		0x100b1 /* TOUCH_SPI_CLK */
+				MX6QDL_PAD_EIM_A19__GPIO2_IO19		0x180b1 /* TOUCH_SPI_CS# */
+				MX6QDL_PAD_EIM_A20__GPIO2_IO18		0x100b1 /* TOUCH_SPI_MOSI */
+				MX6QDL_PAD_EIM_A21__GPIO2_IO17		0x100b1 /* TOUCH_SPI_MISO */
+			>;
+		};
+
+		pinctrl_hog: hoggrp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_3__XTALOSC_REF_CLK_24M	0x10    /* FPGA_24MHZ */
+				MX6QDL_PAD_EIM_DA12__GPIO3_IO12		0x1b088 /* TOUCH_IRQ */
+				MX6QDL_PAD_SD4_DAT3__GPIO2_IO11		0x1b088 /* USB_HUB_RESET# */
+				MX6QDL_PAD_GPIO_16__GPIO7_IO11		0x1b088 /* JTAG_FPGA_TCK */
+				MX6QDL_PAD_GPIO_17__GPIO7_IO12		0x1b088 /* JTAG_FPGA_TDI */
+				MX6QDL_PAD_GPIO_5__GPIO1_IO05		0x1b088 /* JTAG_FPGA_TMS */
+				MX6QDL_PAD_CSI0_MCLK__GPIO5_IO19	0x1b088 /* JTAG_FPGA_TDO */
+				MX6QDL_PAD_DI0_PIN2__GPIO4_IO18		0x1b088 /* EN_232_TRANS */
+				MX6QDL_PAD_EIM_OE__GPIO2_IO25		0x1b088 /* JP_OPTION# */
+				MX6QDL_PAD_EIM_RW__GPIO2_IO26		0x1b088 /* JP_SD_BOOT# */
+				MX6QDL_PAD_EIM_A16__GPIO2_IO22		0x1b088 /* EN_USB_5V */
+				MX6QDL_PAD_EIM_EB1__GPIO2_IO29		0x1b088 /* EN_800_NIT */
+				MX6QDL_PAD_EIM_DA4__GPIO3_IO04		0x1b088 /* 5V_REG_PWM_MODE */
+				MX6QDL_PAD_EIM_DA5__GPIO3_IO05		0x1b088 /* EN_HUB_3.3V */
+				MX6QDL_PAD_EIM_DA9__GPIO3_IO09		0x1b088 /* PUSH_SW_1# */
+				MX6QDL_PAD_EIM_DA10__GPIO3_IO10		0x1b088 /* PUSH_SW_2# */
+				MX6QDL_PAD_EIM_DA2__GPIO3_IO02		0x1b088 /* REVB_STRAP */
+				MX6QDL_PAD_CSI0_PIXCLK__GPIO5_IO18	0x1b088 /* EN_NIM_USB# */
+				MX6QDL_PAD_CSI0_DAT12__GPIO5_IO30	0x1b088 /* NIM_PWR_ON */
+			>;
+		};
+	};
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_pcie>;
+	status = "okay";
+	reset-gpio = <&gpio2 4 GPIO_ACTIVE_LOW>;
+};
+
+&pwm3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_pwm3>;
+	status = "okay";
+};
+
+&snvs_rtc {
+	status = "disabled";
+};
+
+&ssi1 {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart1>;
+};
+
+&uart2 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart2>;
+	uart-has-rtscts;
+};
+
+&uart3 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart3>;
+};
+
+&uart4 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart4>;
+};
+
+&uart5 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart5>;
+};
+
+&usbh1 {
+	status = "okay";
+};
+
+&usbotg {
+	vbus-supply = <&reg_usb_otg_vbus>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_usbotg>;
+	disable-over-current;
+	status = "okay";
+};
+
+&usdhc1 { /* Wifi */
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_usdhc1>;
+	vqmmc-supply = <&reg_wlan_vqmmc>;
+	bus-width = <4>;
+	non-removable;
+	status = "disabled";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+	wl1271: wifi@2 {
+		compatible = "ti,wl1271";
+		reg = <2>;
+		status = "disabled";
+		interrupt-parent = <&gpio1>;
+		interrupts = <26 IRQ_TYPE_LEVEL_HIGH>;
+		ref-clock-frequency = <38400000>;
+	};
+};
+
+&usdhc2 { /* SD */
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_usdhc2>;
+	vmmc-supply = <&reg_3v3>;
+	vqmmc-supply = <&reg_3v3>;
+	bus-width = <4>;
+	fsl,wp-controller;
+	status = "okay";
+};
+
+&usdhc3 { /* eMMC */
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_usdhc3>;
+	vmmc-supply = <&reg_3v3>;
+	vqmmc-supply = <&reg_3v3>;
+	bus-width = <4>;
+	non-removable;
+	no-1-8-v;
+	status = "okay";
+};

--- a/drivers/input/touchscreen/ads7846.c
+++ b/drivers/input/touchscreen/ads7846.c
@@ -1271,6 +1271,7 @@ static const struct ads7846_platform_data *ads7846_probe_dt(struct device *dev)
 }
 #endif
 
+
 static int ads7846_probe(struct spi_device *spi)
 {
 	const struct ads7846_platform_data *pdata;
@@ -1526,12 +1527,23 @@ static int ads7846_remove(struct spi_device *spi)
 	return 0;
 }
 
+static const struct spi_device_id ads7846_spi_id[] = {
+	{ "tsc2046", 0 },
+	{ "ads7843", 0 },
+	{ "ads7845", 0 },
+	{ "ads7846", 0 },
+	{ "ads7873", 0 },
+	{  }
+};
+MODULE_DEVICE_TABLE(spi, ads7846_spi_id);
+
 static struct spi_driver ads7846_driver = {
 	.driver = {
 		.name	= "ads7846",
 		.pm	= &ads7846_pm,
 		.of_match_table = of_match_ptr(ads7846_dt_ids),
 	},
+	.id_table	= ads7846_spi_id,
 	.probe		= ads7846_probe,
 	.remove		= ads7846_remove,
 };

--- a/drivers/input/touchscreen/pixcir_i2c_ts.c
+++ b/drivers/input/touchscreen/pixcir_i2c_ts.c
@@ -81,6 +81,7 @@ struct pixcir_i2c_ts_data {
 	struct gpio_desc *gpio_wake;
 	const struct pixcir_i2c_chip_data *chip;
 	struct touchscreen_properties prop;
+	int irq_polarity;
 	bool running;
 };
 
@@ -345,7 +346,8 @@ static int pixcir_start(struct pixcir_i2c_ts_data *ts)
 	}
 
 	/* LEVEL_TOUCH interrupt with active low polarity */
-	error = pixcir_set_int_mode(ts, PIXCIR_INT_LEVEL_TOUCH, 0);
+	error = pixcir_set_int_mode(ts, PIXCIR_INT_LEVEL_TOUCH,
+					ts->irq_polarity);
 	if (error) {
 		dev_err(dev, "Failed to set interrupt mode: %d\n", error);
 		return error;
@@ -513,6 +515,8 @@ static int pixcir_i2c_ts_probe(struct i2c_client *client,
 	}
 
 	input_set_drvdata(input, tsdata);
+
+	tsdata->irq_polarity = device_property_read_bool(dev, "invert-int-output");
 
 	tsdata->gpio_attb = devm_gpiod_get(dev, "attb", GPIOD_IN);
 	if (IS_ERR(tsdata->gpio_attb)) {


### PR DESCRIPTION
Add support for TS-7990 and variants.

Also includes some driver patches.
- The pixcir driver (LCD cap touch) needed modification to put it in active high IRQ mode. Patch was based on similar modification in linux-tsimx repo.
- The ads7846 driver (Okaya/Microtip resistive touch) did not have an SPI ID struct and therefore fails to auto-load as a module. This will get pushed upstream shortly hopefully but likely won't get backported here so that commit will need to hang around.

As the TS-7990 uses the WILC3000 Wi-Fi module, the defconfig was modified to not enable 802.11 power savings by default as this has been observed to cause issues with the driver.

**NOTE**
This should be merged after #5, in either case there will likely be some conflicts with dts/Makefile that need to be sorted out.

The only variants tested were Quad LXD Rev B, and Quad Okaya Rev B. At this time I do not have any Solo CPUs nor Rev A PCBs.