### PR TITLE
serial: 8250: 8250_ts: Check for error instead of returning line

### DIFF
--- a/drivers/tty/serial/8250/8250_ts.c
+++ b/drivers/tty/serial/8250/8250_ts.c
@@ -29,6 +29,7 @@ static int technologic_ts16550_probe(struct platform_device *pdev)
 	struct uart_8250_port uport;
 	struct uart_port *port;
 	const __be32 *addr_be;
+	int line;
 
 	memset(&uport, 0, sizeof(uport));
 
@@ -52,7 +53,16 @@ static int technologic_ts16550_probe(struct platform_device *pdev)
 	port->serial_in = tsisa_serial_in;
 	port->serial_out = tsisa_serial_out;
 
-	return serial8250_register_8250_port(&uport);
+	line = serial8250_register_8250_port(&uport);
+
+	if (line < 0) {
+		dev_err(dev,
+			"serial8250_register_8250_port() 0x%X irq %d failed\n",
+			port->mapbase, port->irq);
+		return line;
+	}
+
+	return 0;
 }
 
 static const struct of_device_id ts16550_of_match[] = {


### PR DESCRIPTION
Before this change it works when loading a single 8250 port, but with multiple it reports a failure:
[    1.248351] serial8250: ttyS0 at MMIO 0x3e8 (irq = 242, base_baud = 115200) is a 16550A
[    1.251118] serial8250: ttyS1 at MMIO 0x2e8 (irq = 242, base_baud = 115200) is a 16550A
[    1.252223] ts16550: probe of 50004050.fpgaisa:ts16550@2e8 failed with error 1

further UARTs would fail with errors 2, 3, 4, etc.

Both ports are still functional, but serial8250_register_8250_port returns the allocated line number (or negative on failure), and not 0 on success as the previous code assumed. This fixes the error message.