### PR TITLE
ARM: dts: ts7400v2: Remove mmc aliases

### DIFF
--- a/arch/arm/boot/dts/imx28-ts7400v2.dts
+++ b/arch/arm/boot/dts/imx28-ts7400v2.dts
@@ -14,8 +14,6 @@
 	compatible = "fsl,imx28-ts7400v2", "fsl,imx28";
 
 	aliases {
-		mmc0 = &ssp0;
-		mmc2 = &ssp1;
 		spi0 = &ssp2;
 		i2c0 = &i2c0;
 	};


### PR DESCRIPTION
There is a long history as to why the aliases were there, they worked on the stock kernel for the TS-7400-V2, did not work in 4.9, and again work in 5.10.

The issue is that the U-Boot binary expects the eMMC to be at mmcblk1. This U-Boot was created specifically for the 4.9 kernel. In 5.10 where the alias was honored, it was showing up at mmcblk2 and resulting in a hang waiting for a non-existant device node.