### PR TITLE
ARM: dts: ts7180: fix merge typo

### DIFF
--- a/arch/arm/boot/dts/imx6ul-ts7180.dts
+++ b/arch/arm/boot/dts/imx6ul-ts7180.dts
@@ -682,7 +682,6 @@
 &uart4 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart4>;
-	status = "okay";
 	rts-gpios = <&gpio1 19 GPIO_ACTIVE_HIGH>;
 	linux,rs485-enabled-at-boot-time;
 	dma-names = "", "";


### PR DESCRIPTION
Spotted this when diffing my local tree against 5.10.y after the merge. Figured it's better than to have a fix available to merge than to forget about it.
