### PR TITLE
pwm: pwm-ts: Fix inversed before enabling pwm

### DIFF
--- a/drivers/pwm/pwm-ts.c
+++ b/drivers/pwm/pwm-ts.c
@@ -100,9 +100,7 @@ static int ts_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
 	int err;
 	u16 ctrl = 0;
 
-	if (state->polarity == PWM_POLARITY_NORMAL)
-		ctrl &= ~INVERSED;
-	else
+	if (state->polarity != PWM_POLARITY_NORMAL)
 		ctrl |= INVERSED;
 
 	if (state->enabled)


### PR DESCRIPTION
This allows inversed to be set without first turning on the PWM. This also removes the state in the ts object that was tracking state, and now the calc function sets the registers. Removed the spinlock which is not used or needed.