### PR TITLE
ARM: dts: imx28: fix enet flapping issue

### DIFF
--- a/arch/arm/boot/dts/imx28-ts7400v2.dts
+++ b/arch/arm/boot/dts/imx28-ts7400v2.dts
@@ -200,7 +200,7 @@
 	phy-supply = <&reg_enet_3v3>;
 	phy-handle = <&ethphy0>;
 	phy-reset-gpios = <&gpio2 9 GPIO_ACTIVE_LOW>;
-	phy-reset-duration = <26>;
+	phy-reset-duration = <100>;
 	phy-reset-post-delay = <1>;
 	status = "okay";
 
@@ -210,6 +210,9 @@
 
 		ethphy0: ethernet-phy@0 {
 			compatible = "ethernet-phy-ieee802.3-c22";
+			/* magic number "64" is enet out from CPU */
+			clocks = <&clks 64>;
+			clock-names = "rmii-ref";
 			reg = <0>;
 		};
 	};

--- a/arch/arm/boot/dts/imx28-ts7670.dts
+++ b/arch/arm/boot/dts/imx28-ts7670.dts
@@ -228,7 +228,7 @@
 	phy-supply = <&reg_enet_3v3>;
 	phy-handle = <&ethphy0>;
 	phy-reset-gpios = <&gpio2 9 GPIO_ACTIVE_LOW>;
-	phy-reset-duration = <26>;
+	phy-reset-duration = <100>;
 	phy-reset-post-delay = <1>;
 	status = "okay";
 
@@ -238,6 +238,9 @@
 
 		ethphy0: ethernet-phy@0 {
 			compatible = "ethernet-phy-ieee802.3-c22";
+			/* magic number "64" is enet out from CPU */
+			clocks = <&clks 64>;
+			clock-names = "rmii-ref";
 			reg = <0>;
 		};
 	};


### PR DESCRIPTION
I want to highlight a couple things about this moving forward.

Any time we use a CPU clock to drive a PHY, this clock _needs_ to be added to the `ethphy` handle. It looks like we do this in some places already. Any new devicetrees need to have this.