### PR TITLE
ARM: dts: ts4100-8551: reduce SPI speed to FRAM

### DIFF
--- a/arch/arm/boot/dts/imx6ul-ts4100-ts8551.dtsi
+++ b/arch/arm/boot/dts/imx6ul-ts4100-ts8551.dtsi
@@ -17,7 +17,7 @@
         spifram: eeprom@1 {
                 compatible = "atmel,at25", "cypress,fm25l16b";
                 reg = <1>;
-                spi-max-frequency = <20000000>;
+                spi-max-frequency = <2000000>;
                 size = <0x800>;
                 address-width = <16>;
                 pagesize = <64>;


### PR DESCRIPTION
Due to it being offboard, the added connections and trace lengths cause rare glitches at the full bus speed