### PR TITLE
serial: 8250: 8250_ts: Enable RS-485 through RTS

### DIFF
--- a/drivers/tty/serial/8250/8250_ts.c
+++ b/drivers/tty/serial/8250/8250_ts.c
@@ -8,6 +8,8 @@
 #include <linux/serial_8250.h>
 #include <linux/tspc104_bus.h>
 
+#include "8250.h"
+
 static unsigned int tsisa_serial_in(struct uart_port *p, int offset)
 {
 	struct tspc104_bus *bus = (struct tspc104_bus *)p->private_data;
@@ -52,6 +54,9 @@ static int technologic_ts16550_probe(struct platform_device *pdev)
 	port->type = PORT_16550A;
 	port->serial_in = tsisa_serial_in;
 	port->serial_out = tsisa_serial_out;
+	port->rs485_config = serial8250_em485_config;
+	uport.rs485_start_tx = serial8250_em485_start_tx;
+	uport.rs485_stop_tx = serial8250_em485_stop_tx;
 
 	line = serial8250_register_8250_port(&uport);
 


### PR DESCRIPTION
This adds support for RS-485 on our PC/104 uart devices by having the kernel automatically control RTS around transactions.