### PR TITLE
6.6: i.MX28: fix userspace PWM not enabling properly

### DIFF
--- a/drivers/pwm/pwm-mxs.c
+++ b/drivers/pwm/pwm-mxs.c
@@ -99,21 +99,28 @@ static int mxs_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
 	writel(PERIOD_PERIOD(period_cycles) | pol_bits | PERIOD_CDIV(div),
 	       mxs->base + PWM_PERIOD0 + pwm->hwpwm * 0x20);
 
-	/*
-	 * If the PWM is not enabled, turn the clock off again to save power.
-	 */
-	/* XXX:
-	 * Do not ever let the clock get turned off on a TS-7680
-	 * The new atomic PWM API means that all PWMs start out as disabled
-	 * This is one of the contributing factors to the clock glitch that
-	 * occurs at startup. U-Boot sets everthing up properly in the case of
-	 * the TS-7680.
-	 */
-	if (!of_machine_is_compatible("fsl,imx28-ts7680")) {
-		if (!pwm_is_enabled(pwm))
+	if (state->enabled) {
+		if (!pwm_is_enabled(pwm)) {
+			/*
+			 * The clock was enabled above. Just enable
+			 * the channel in the control register.
+			 */
+			writel(1 << pwm->hwpwm, mxs->base + PWM_CTRL + SET);
+		}
+	} else {
+		/*
+		 * If the PWM is not enabled, turn the clock off again to save power.
+		 */
+		/* XXX:
+		 * Do not ever let the clock get turned off on a TS-7680
+		 * The new atomic PWM API means that all PWMs start out as disabled
+		 * This is one of the contributing factors to the clock glitch that
+		 * occurs at startup. U-Boot sets everthing up properly in the case of
+		 * the TS-7680.
+		 */
+		if (!of_machine_is_compatible("fsl,imx28-ts7680"))
 			clk_disable_unprepare(mxs->clk);
 	}
-
 	return 0;
 }
 


### PR DESCRIPTION
Cherry-picked in to this branch from 5.10.y. No i.MX28 platforms currently supported in this branch, however, bringing over the commit for completeness.