### PR TITLE
5.10.y: ARM: dts: imx6ul: ts7100-3: Enable uart2 and uart5

### DIFF
--- a/arch/arm/boot/dts/imx6ul-ts7100-3.dtsi
+++ b/arch/arm/boot/dts/imx6ul-ts7100-3.dtsi
@@ -199,7 +199,6 @@
 &uart2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart2>;
-	uart-has-rtscts;
 	rts-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 	linux,rs485-enabled-at-boot-time;
 	dma-names = "", "";
@@ -223,7 +222,7 @@
 &uart5 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart5>;
-	uart-has-rtscts;
+	rts-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 	linux,rs485-enabled-at-boot-time;
 	dma-names = "", "";
 	status = "okay";

--- a/arch/arm/boot/dts/imx6ul-ts7100-3.dtsi
+++ b/arch/arm/boot/dts/imx6ul-ts7100-3.dtsi
@@ -199,7 +199,7 @@
 &uart2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart2>;
-	rts-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+	rts-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
 	linux,rs485-enabled-at-boot-time;
 	dma-names = "", "";
 	status = "okay";
@@ -222,7 +222,7 @@
 &uart5 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart5>;
-	rts-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+	rts-gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 	linux,rs485-enabled-at-boot-time;
 	dma-names = "", "";
 	status = "okay";

--- a/arch/arm/boot/dts/imx6ul-ts7100-3.dtsi
+++ b/arch/arm/boot/dts/imx6ul-ts7100-3.dtsi
@@ -203,6 +203,7 @@
 	rts-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 	linux,rs485-enabled-at-boot-time;
 	dma-names = "", "";
+	status = "okay";
 };
 
 &uart3 {
@@ -225,6 +226,7 @@
 	uart-has-rtscts;
 	linux,rs485-enabled-at-boot-time;
 	dma-names = "", "";
+	status = "okay";
 };
 
 &usbotg1 {


### PR DESCRIPTION
These were never explicitly enabled in the devicetree