### PR TITLE
 TS-7180: invert CS polarity for HD12/8 SPI

### DIFF
--- a/arch/arm/boot/dts/imx6ul-ts7180.dts
+++ b/arch/arm/boot/dts/imx6ul-ts7180.dts
@@ -136,7 +136,7 @@
 
 &ecspi3 {
 	num-cs = <3>;
-	cs-gpios = <&gpio4 12 GPIO_ACTIVE_LOW>, <&gpio3 0 GPIO_ACTIVE_LOW>, <&gpio4 27 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio4 12 GPIO_ACTIVE_LOW>, <&gpio3 0 GPIO_ACTIVE_HIGH>, <&gpio4 27 GPIO_ACTIVE_LOW>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_ecspi3>;
 	status = "okay";


### PR DESCRIPTION
In order to be 5 V tolerant, this CS is actually driven through a FET which causes a logical polarity inversion.