### PR TITLE
ARM: dts: imx6ul: ts7180: add spi-cs-high property to DC node

### DIFF
--- a/arch/arm/boot/dts/imx6ul-ts7180.dts
+++ b/arch/arm/boot/dts/imx6ul-ts7180.dts
@@ -151,6 +151,7 @@
 		compatible = "technologic,spi-header";
 		reg = <1>;
 		spi-max-frequency = <1000000>;
+		spi-cs-high;
 	};
 
 	/* This is actually the FRAM, which is compatible with the AT25 SPI EEPROM */


### PR DESCRIPTION
For SPI to use an inverted CS polarity with cs-gpios, both the GPIO needs to be specified with GPIO_ACTIVE_HIGH -and- the device node needs the spi-cs-high property.