### PR TITLE
linux-6.6.y: Fix compatible node used for iis2mdctr

### DIFF
--- a/arch/arm/boot/dts/nxp/imx/imx6qdl-ts7990.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imx6qdl-ts7990.dtsi
@@ -292,7 +292,7 @@
 
 	/* Only present on REV E and above */
 	magnet: magnetometer@1e {
-		compatible = "st,lis2mdl";
+		compatible = "st,iis2mdc";
 		reg = <0x1e>;
 		st,drdy-int-pin = <1>;
 		interrupt-parent = <&gpio2>;

--- a/arch/arm/boot/dts/nxp/imx/imx6ul-ts7100.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imx6ul-ts7100.dtsi
@@ -156,7 +156,7 @@
 	status = "okay";
 
 	st_magn: magnetometer@1e {
-		compatible = "st,lis2mdl";
+		compatible = "st,iis2mdc";
 		/* This option isn't valid on this part as it only supports
 		 * a single drdy pin. However, the driver defaults to int2 if
 		 * not drdy pin is specified which the driver errors on if int2

--- a/arch/arm/boot/dts/nxp/imx/imx6ul-ts7180.dts
+++ b/arch/arm/boot/dts/nxp/imx/imx6ul-ts7180.dts
@@ -290,7 +290,7 @@
 	status = "okay";
 
 	st_magn: magnetometer@1e {
-		compatible = "st,lis2mdl";
+		compatible = "st,iis2mdc";
 		reg = <0x1e>;
 		st,drdy-int-pin = <1>;
 		interrupt-parent = <&gpio4>;

--- a/arch/arm/boot/dts/nxp/imx/imx6ul-ts7250v3.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imx6ul-ts7250v3.dtsi
@@ -137,7 +137,7 @@
 	status = "okay";
 
 	magnet: magnetometer@1e {
-		compatible = "st,lis2mdl";
+		compatible = "st,iis2mdc";
 		reg = <0x1e>;
 		st,drdy-int-pin = <1>;
 		interrupt-parent = <&gpio1>;

--- a/arch/arm/boot/dts/nxp/imx/imx6ul-ts7553v2.dts
+++ b/arch/arm/boot/dts/nxp/imx/imx6ul-ts7553v2.dts
@@ -126,8 +126,8 @@
 		sda-gpios = <&gpio5 5 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
 		scl-gpios = <&gpio5 4 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
 
-		lis2mdl: magnetometer@1e {
-			compatible = "st,lis2mdl";
+		iis2mdc: magnetometer@1e {
+			compatible = "st,iis2mdc";
 			reg = <0x1e>;
 			pinctrl-names = "default";
 			pinctrl-0 = <&pinctrl_magn_gpio>;


### PR DESCRIPTION
In the previous 5.10 kernel, there was no node for the iis2mdctr, but is functionally the same as lis2mdl. Since this compatible string is now in 6.6 and later we should change to this.