### PR TITLE
linux-6.6.y: ARM: dts: imx6ul-ts7100-3: support rev C TS-7100-3

### DIFF
--- a/arch/arm/boot/dts/nxp/imx/imx6ul-ts7100-3.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imx6ul-ts7100-3.dtsi
@@ -9,24 +9,6 @@
 		gpio6 = &fpga_gpio1;
 		gpio7 = &fpga_gpio2;
 	};
-
-	led-controller {
-		compatible = "gpio-leds";
-
-		led-2 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_INDICATOR;
-			gpios = <&fpga_gpio1 9 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-
-		led-3 {
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_INDICATOR;
-			gpios = <&fpga_gpio1 8 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-	};
 };
 
 &ecspi3 {
@@ -45,6 +27,12 @@
 		interrupt-parent = <&gpio1>;
 		interrupts = <11 GPIO_ACTIVE_HIGH>;
 	};
+};
+
+&fpga_uart0 {
+	/* GPIO hog configures this pin */
+	/* IO set to keeper since transceiver has PD */
+	rs485-term-gpios = <&gpio4 7 GPIO_ACTIVE_HIGH>;
 };
 
 /* CPU GPIO1: 209c000.gpio */
@@ -100,7 +88,7 @@
 	gpio-line-names =
 		"EN_EMMC_3V3#",   "EN_ADC1_12V",    "EN_ADC2_12V",    "EN_ADC3_12V",
 		"EN_ADC4_12V",    "EN_USB_HOST_5V", "PHY_RESET#",     "WIFI_RESET#",
-		"IO_RED_LED#",    "IO_GREEN_LED#",  "",               "",
+		"",               "",               "",               "",
 		"EN_PROG_SILAB",  "DIO_3_OUT",      "EN_HSPWM",       "EN_LSPWM";
 };
 
@@ -124,6 +112,7 @@
 				 * All GPIO should be 0x1b020 unless special
 				 * 0x1b020 == Hyst., 100k PU, 50 mA drive
 				 * 0x1a020 == no pull resistor
+				 * 0x11020 == keeper
 				 * 0x13020 == 100k PD
 				 */
 
@@ -142,7 +131,7 @@
 				/* NIM_RESET */
 				MX6UL_PAD_SNVS_TAMPER6__GPIO5_IO06	0x1b020
 				/* FPGA Spares */
-				MX6UL_PAD_SNVS_TAMPER7__GPIO5_IO07	0x1b020
+				MX6UL_PAD_SNVS_TAMPER7__GPIO5_IO07	0x11020
 				MX6UL_PAD_SNVS_TAMPER8__GPIO5_IO08	0x1b020
 				MX6UL_PAD_SNVS_TAMPER9__GPIO5_IO09	0x1b020
 			>;
@@ -207,6 +196,8 @@
 	pinctrl-0 = <&pinctrl_uart2>;
 	rts-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
 	linux,rs485-enabled-at-boot-time;
+	/* No configuration of pin needed, no pull in FPGA, relies on pull in xceiver */
+	rs485-term-gpios = <&fpga_gpio1 8 GPIO_ACTIVE_HIGH>;
 	dma-names = "", "";
 	status = "okay";
 };
@@ -230,6 +221,8 @@
 	pinctrl-0 = <&pinctrl_uart5>;
 	rts-gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 	linux,rs485-enabled-at-boot-time;
+	/* No configuration of pin needed, no pull in FPGA, relies on pull in xceiver */
+	rs485-term-gpios = <&fpga_gpio1 9 GPIO_ACTIVE_HIGH>;
 	dma-names = "", "";
 	status = "okay";
 };


### PR DESCRIPTION
Adds RS-485 termination resistor control via ioctl

Test code:
```
/*
 * Proof-of-Concept test to enable/disable RS-485 termination on TS-7100-3
 * using THVD1424 RS-485 transcievers with termination control connected to GPIO
 * pins.
 */

#include <errno.h>
#include <fcntl.h>
#include <linux/serial.h>
#include <stdio.h>
#include <stdlib.h>
#include <sys/ioctl.h>
#include <unistd.h>

void main(int argc, char *argv[]) {
        struct serial_rs485 rs485conf = {0};
        int fd;

        if (argc != 2) {
                fprintf(stderr, "Must supply serial port!\n");
                fprintf(stderr, "example: \'%s /dev/tty...\'\n", argv[0]);
                exit(-1);
        }

        fd = open (argv[1], O_RDWR);
        if (fd < 0) {
                fprintf(stderr, "Unable to open serial port \'%s\': ", argv[1]);
                perror(NULL);
                exit(errno);
        }


        /* Enable RS485 mode: */
        rs485conf.flags |= SER_RS485_ENABLED | SER_RS485_TERMINATE_BUS;

        printf("Press [enter] to toggle RS-485 termination\n");

        for (;;) {

                if (ioctl (fd, TIOCSRS485, &rs485conf) < 0) {
                        perror("Unable to set ioctl");
                        exit(errno);
                }

                printf("RS-485 Termination %s\n",
                        (rs485conf.flags & SER_RS485_TERMINATE_BUS) ?
                        "Enabled" : "Disabled");
                getchar();

                rs485conf.flags ^= SER_RS485_TERMINATE_BUS;
        }

        close(fd);
}
```

Test procedure:
Test was run on a Rev A TS-7100-Z PCB which does not have the required transceivers. This was accomplished by simply copying the `/boot/imx6ul-ts7100-3.dtb` file overtop `/boot/imx6ul-ts7100-1.dtb` and booting. 
Test was quite manual since the GPIO used for `ttyS0` is not able to be externally read easily, and then the GPIOs for `ttymxc1` and `ttymxc4` use the same GPIO used to drive the TS-7100-Z's IO board's green and red LEDs

```
gcc rs485test.c -o rs485test
./rs485test /dev/ttyS0
Press [enter] to toggle RS-485 termination
RS-485 Termination Enabled
[ctrl+z]
cat /sys/kernel/debug/gpio |grep 103
 gpio-103 (                    |rs485-term          ) out hi 
fg
./rs485test /dev/ttyS0
[enter]
RS-485 Termination Disabled
[ctrl+z]
cat /sys/kernel/debug/gpio |grep 103
 gpio-103 (                    |rs485-term          ) out lo
 fg
 [ctrl+c]
 
./rs485test /dev/ttymxc1 
Press [enter] to toggle RS-485 termination
RS-485 Termination Enabled (red LED off)
[enter]
RS-485 Termination Disabled (red LED on)
[enter]
RS-485 Termination Enabled (red LED off)
[enter]
RS-485 Termination Disabled (red LED on)
[enter]
[ctrl+c]

./rs485test /dev/ttymxc4
Press [enter] to toggle RS-485 termination
RS-485 Termination Enabled (green LED off)
[enter]
RS-485 Termination Disabled (green LED on)
[enter]
RS-485 Termination Enabled (green LED off)
[enter]
RS-485 Termination Disabled (green LED on)
[enter]
[ctrl+c]