### PR TITLE
6.6: Fix TS-7100 CTS pin

### DIFF
--- a/arch/arm/boot/dts/nxp/imx/imx6ul-ts7100-3.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imx6ul-ts7100-3.dtsi
@@ -213,7 +213,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart4>;
 	status = "okay";
-	rts-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+	cts-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
 };
 
 &uart5 {

--- a/arch/arm/boot/dts/nxp/imx/imx6ul-ts7100-z.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imx6ul-ts7100-z.dtsi
@@ -220,7 +220,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart4>;
 	status = "okay";
-	rts-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+	cts-gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
 };
 
 &uart5 {


### PR DESCRIPTION
Linux refers to CTS as the input:

```
static const struct {
	const char *name;
	unsigned int mctrl;
	enum gpiod_flags flags;
} mctrl_gpios_desc[UART_GPIO_MAX] = {
	{ "cts", TIOCM_CTS, GPIOD_IN, },
	{ "dsr", TIOCM_DSR, GPIOD_IN, },
	{ "dcd", TIOCM_CD,  GPIOD_IN, },
	{ "rng", TIOCM_RNG, GPIOD_IN, },
	{ "rts", TIOCM_RTS, GPIOD_OUT_LOW, },
	{ "dtr", TIOCM_DTR, GPIOD_OUT_LOW, },
};
```

The skywire documentation suggests pin 12 is an output.  This should be cts, not rts to use as an input on our board.