### PR TITLE
iio: adc: tswizard: use correct MODULE_DEVICE_TABLE for OF compatible

### DIFF
--- a/drivers/iio/adc/tswizard_adc.c
+++ b/drivers/iio/adc/tswizard_adc.c
@@ -153,7 +153,7 @@ static const struct of_device_id tswizard_of_match[] = {
 	{ .compatible = "technologic,tswizard-adc", },
 	{ }
 };
-MODULE_DEVICE_TABLE(of, tsadc_of_match);
+MODULE_DEVICE_TABLE(of, tswizard_of_match);
 
 static struct platform_driver tsadc_driver = {
 	.driver = {


### PR DESCRIPTION
Fixes: 42a8750adaf39 ("iio: tssupervisor-adc: Initial commit of embeddedTS supervisory microcontroller ADC")
Fixes: fdeff8d9f56b8 ("ARM: embeddedts: rename tssupervisor subsystem to tswizard (#225)")