### PR TITLE
ts71xxweim: extend IRQ functionality for interrupt controller and gpio controller

### DIFF
--- a/arch/arm/boot/dts/nxp/imx/imx6ul-ts7250v3.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imx6ul-ts7250v3.dtsi
@@ -431,6 +431,10 @@
 				reg = <0x10 0x08>;
 				gpio-controller;
 				#gpio-cells = <2>;
+
+				interrupt-parent = <&fpga_intc>;
+				interrupts = <21 IRQ_TYPE_LEVEL_HIGH>;
+
 				interrupt-controller;
 				#interrupt-cells = <1>;
 
@@ -447,6 +451,10 @@
 				reg = <0x40 0x08>;
 				gpio-controller;
 				#gpio-cells = <2>;
+
+				interrupt-parent = <&fpga_intc>;
+				interrupts = <22 IRQ_TYPE_LEVEL_HIGH>;
+
 				interrupt-controller;
 				#interrupt-cells = <1>;
 
@@ -463,6 +471,10 @@
 				reg = <0x54 0x08>;
 				gpio-controller;
 				#gpio-cells = <2>;
+
+				interrupt-parent = <&fpga_intc>;
+				interrupts = <23 IRQ_TYPE_LEVEL_HIGH>;
+
 				interrupt-controller;
 				#interrupt-cells = <1>;
 
@@ -481,6 +493,10 @@
 				reg = <0x5c 0x08>;
 				gpio-controller;
 				#gpio-cells = <2>;
+
+				interrupt-parent = <&fpga_intc>;
+				interrupts = <24 IRQ_TYPE_LEVEL_HIGH>;
+
 				interrupt-controller;
 				#interrupt-cells = <1>;
 
@@ -497,6 +513,10 @@
 				reg = <0x64 0x08>;
 				gpio-controller;
 				#gpio-cells = <2>;
+
+				interrupt-parent = <&fpga_intc>;
+				interrupts = <25 IRQ_TYPE_LEVEL_HIGH>;
+
 				interrupt-controller;
 				#interrupt-cells = <1>;
 
@@ -515,6 +535,10 @@
 				reg = <0x6c 0x08>;
 				gpio-controller;
 				#gpio-cells = <2>;
+
+				interrupt-parent = <&fpga_intc>;
+				interrupts = <26 IRQ_TYPE_LEVEL_HIGH>;
+
 				interrupt-controller;
 				#interrupt-cells = <1>;
 

--- a/arch/arm/boot/dts/nxp/imx/imx6ul-ts7250v3.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imx6ul-ts7250v3.dtsi
@@ -428,7 +428,7 @@
 
 			fpga_bank0: fpga_gpio@10 {
 				compatible = "technologic,ts71xxweim-gpio";
-				reg = <0x10 0x08>;
+				reg = <0x10 0x08>, <0x80 0x10>;
 				gpio-controller;
 				#gpio-cells = <2>;
 
@@ -448,7 +448,7 @@
 
 			fpga_bank1: fpga_gpio@40 {
 				compatible = "technologic,ts71xxweim-gpio";
-				reg = <0x40 0x08>;
+				reg = <0x40 0x08>, <0x90 0x10>;
 				gpio-controller;
 				#gpio-cells = <2>;
 
@@ -468,7 +468,7 @@
 
 			fpga_bank2: fpga_gpio@54 {
 				compatible = "technologic,ts71xxweim-gpio";
-				reg = <0x54 0x08>;
+				reg = <0x54 0x08>, <0xa0 0x10>;
 				gpio-controller;
 				#gpio-cells = <2>;
 
@@ -490,7 +490,7 @@
 
 			fpga_bank3: fpga_gpio@5c {
 				compatible = "technologic,ts71xxweim-gpio";
-				reg = <0x5c 0x08>;
+				reg = <0x5c 0x08>, <0xb0 0x10>;
 				gpio-controller;
 				#gpio-cells = <2>;
 
@@ -510,7 +510,7 @@
 
 			fpga_bank4: fpga_gpio@64 {
 				compatible = "technologic,ts71xxweim-gpio";
-				reg = <0x64 0x08>;
+				reg = <0x64 0x08>, <0xc0 0x10>;
 				gpio-controller;
 				#gpio-cells = <2>;
 
@@ -532,7 +532,7 @@
 
 			fpga_bank5: fpga_gpio@6c {
 				compatible = "technologic,ts71xxweim-gpio";
-				reg = <0x6c 0x08>;
+				reg = <0x6c 0x08>, <0xd0 0x10>;
 				gpio-controller;
 				#gpio-cells = <2>;
 

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -795,6 +795,7 @@ config GPIO_LOONGSON1
 config GPIO_TS71XXWEIM
 	bool "embeddedTS WEIM FPGA GPIO"
 	depends on IMX_WEIM
+	select GPIOLIB_IRQCHIP
 	help
 	  Say yes here to enable the GPIO driver for embeddedTS's FPGA core
 	  connected to the i.MX6UL WEIM bus.

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -112,17 +112,13 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 	struct resource *res;
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-	if (res == NULL) {
-		pr_err("Can't get device address\n");
+	if (res == NULL)
 		return -EFAULT;
-	}
 
 	membase =  devm_ioremap(&pdev->dev, res->start,
 					  resource_size(res));
-	if (IS_ERR(membase)) {
-		pr_err("Could not map resource\n");
+	if (IS_ERR(membase))
 		return -ENOMEM;
-	}
 
 	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
 	if (!priv)

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -6,8 +6,11 @@
 
 #include <linux/gpio/driver.h>
 #include <linux/of_device.h>
+#include <linux/of_irq.h>
+#include <linux/interrupt.h>
 #include <linux/module.h>
 #include <linux/delay.h>
+#include <linux/seq_file.h>
 
 /* Most that this driver can currently support in a single bank is 16. This is
  * due simply to how the FPGA used for these devices is structured.
@@ -21,9 +24,20 @@
 #define TSWEIM_CLR_REG		0x04
 #define TSWEIM_EN_CLR_REG	0x06
 
+/* The IRQ registers are from a second register range */
+#define TSWEIM_GPIO_IRQ_ACK		0x0
+#define TSWEIM_GPIO_IRQ_ACK_MASK	0x2
+#define TSWEIM_GPIO_IRQ_EDGE_LEVEL	0x4
+#define TSWEIM_GPIO_IRQ_EDGE_SEL	0x6
+#define TSWEIM_GPIO_IRQ_POLARITY	0x8
+#define TSWEIM_GPIO_IRQ_MASK		0xA
+#define TSWEIM_GPIO_IRQ_PENDING		0xC
+
 struct tsweim_gpio_priv {
 	void __iomem *base;
+	void __iomem *irqbase;
 	struct gpio_chip gpio_chip;
+	spinlock_t lock;
 };
 
 static inline struct tsweim_gpio_priv *to_gpio_tsweim(struct gpio_chip *chip)
@@ -48,9 +62,12 @@ static int tsweim_gpio_direction_output(struct gpio_chip *chip,
 					unsigned int offset, int value)
 {
 	struct tsweim_gpio_priv *priv = to_gpio_tsweim(chip);
+	unsigned long flags;
 
 	if (!(offset < priv->gpio_chip.ngpio))
 		return -EINVAL;
+
+	spin_lock_irqsave(&priv->lock, flags);
 
 	if (value)
 		writew((1 << offset), priv->base + TSWEIM_SET_REG);
@@ -58,6 +75,8 @@ static int tsweim_gpio_direction_output(struct gpio_chip *chip,
 		writew((1 << offset), priv->base + TSWEIM_CLR_REG);
 
 	writew((1 << offset), priv->base + TSWEIM_EN_SET_REG);
+
+	spin_unlock_irqrestore(&priv->lock, flags);
 
 	return 0;
 }
@@ -98,6 +117,150 @@ static const struct gpio_chip tsweim_gpio_chip = {
 	.can_sleep		= false,
 };
 
+static void gpio_tsweim_irq_handler(struct irq_desc *desc)
+{
+	struct gpio_chip *gc = irq_desc_get_handler_data(desc);
+	struct tsweim_gpio_priv *priv = gpiochip_get_data(gc);
+	struct irq_chip *irq_chip = irq_desc_get_chip(desc);
+	unsigned long pending, bit;
+
+	chained_irq_enter(irq_chip, desc);
+
+	pending = readw(priv->irqbase + TSWEIM_GPIO_IRQ_PENDING);
+
+	for_each_set_bit(bit, &pending, 16) {
+		generic_handle_domain_irq(gc->irq.domain, bit);
+	}
+
+	chained_irq_exit(irq_chip, desc);
+}
+
+static void gpio_tsweim_irq_ack(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct tsweim_gpio_priv *priv = gpiochip_get_data(gc);
+	unsigned long flags;
+	u16 reg;
+
+	spin_lock_irqsave(&priv->lock, flags);
+
+	reg = readw(priv->irqbase + TSWEIM_GPIO_IRQ_ACK) | BIT(irqd_to_hwirq(d));
+	writew(reg, priv->irqbase + TSWEIM_GPIO_IRQ_ACK);
+
+	spin_unlock_irqrestore(&priv->lock, flags);
+}
+
+static void gpio_tsweim_irq_mask(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct tsweim_gpio_priv *priv = gpiochip_get_data(gc);
+	unsigned long flags;
+	u16 mask;
+
+	spin_lock_irqsave(&priv->lock, flags);
+
+	mask = readw(priv->irqbase + TSWEIM_GPIO_IRQ_MASK) | BIT(irqd_to_hwirq(d));
+	writew(mask, priv->irqbase + TSWEIM_GPIO_IRQ_MASK);
+
+	spin_unlock_irqrestore(&priv->lock, flags);
+
+	gpiochip_disable_irq(gc, d->hwirq);
+}
+
+static void gpio_tsweim_irq_unmask(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct tsweim_gpio_priv *priv = gpiochip_get_data(gc);
+	unsigned long flags;
+	u16 mask;
+
+	gpiochip_enable_irq(gc, d->hwirq);
+
+	spin_lock_irqsave(&priv->lock, flags);
+
+	mask = readw(priv->irqbase + TSWEIM_GPIO_IRQ_MASK) & ~BIT(irqd_to_hwirq(d));
+	writew(mask, priv->irqbase + TSWEIM_GPIO_IRQ_MASK);
+
+	spin_unlock_irqrestore(&priv->lock, flags);
+}
+
+static int gpio_tsweim_irq_set_type(struct irq_data *d, unsigned int type)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct tsweim_gpio_priv *priv = gpiochip_get_data(gc);
+	unsigned int hwirq = irqd_to_hwirq(d);
+	u16 polarity, edge, edge_sel;
+	unsigned long flags;
+
+	spin_lock_irqsave(&priv->lock, flags);
+
+	polarity = readw(priv->irqbase + TSWEIM_GPIO_IRQ_POLARITY);
+	edge = readw(priv->irqbase + TSWEIM_GPIO_IRQ_EDGE_LEVEL);
+	edge_sel = readw(priv->irqbase + TSWEIM_GPIO_IRQ_EDGE_SEL);
+
+	switch (type & IRQ_TYPE_SENSE_MASK) {
+	case IRQ_TYPE_LEVEL_HIGH:
+		edge &= ~BIT(hwirq);
+		edge_sel &= ~BIT(hwirq);
+		polarity |= BIT(hwirq);
+		irq_set_handler_locked(d, handle_level_irq);
+		break;
+	case IRQ_TYPE_LEVEL_LOW:
+		edge &= ~BIT(hwirq);
+		edge_sel &= ~BIT(hwirq);
+		polarity &= ~BIT(hwirq);
+		irq_set_handler_locked(d, handle_level_irq);
+		break;
+	case IRQ_TYPE_EDGE_RISING:
+		edge |= BIT(hwirq);
+		edge_sel &= ~BIT(hwirq);
+		polarity |= BIT(hwirq);
+		irq_set_handler_locked(d, handle_edge_irq);
+		break;
+	case IRQ_TYPE_EDGE_FALLING:
+		edge |= BIT(hwirq);
+		edge_sel &= ~BIT(hwirq);
+		polarity &= ~BIT(hwirq);
+		irq_set_handler_locked(d, handle_edge_irq);
+		break;
+	case IRQ_TYPE_EDGE_BOTH:
+		edge |= BIT(hwirq);
+		edge_sel |= BIT(hwirq);
+		polarity &= ~BIT(hwirq);
+		irq_set_handler_locked(d, handle_edge_irq);
+		break;
+	default:
+		spin_unlock_irqrestore(&priv->lock, flags);
+		return -EINVAL;
+	}
+
+	writew(polarity, priv->irqbase + TSWEIM_GPIO_IRQ_POLARITY);
+	writew(edge, priv->irqbase + TSWEIM_GPIO_IRQ_EDGE_LEVEL);
+	writew(edge_sel, priv->irqbase + TSWEIM_GPIO_IRQ_EDGE_SEL);
+
+	spin_unlock_irqrestore(&priv->lock, flags);
+
+	return 0;
+}
+
+static void gpio_tsweim_irq_print_chip(struct irq_data *data, struct seq_file *p)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(data);
+
+	seq_printf(p, dev_name(gc->parent));
+}
+
+static const struct irq_chip tsweim_irq_chip = {
+	.name			= "tsweim_gpio_irq",
+	.irq_ack		= gpio_tsweim_irq_ack,
+	.irq_mask		= gpio_tsweim_irq_mask,
+	.irq_unmask		= gpio_tsweim_irq_unmask,
+	.irq_set_type		= gpio_tsweim_irq_set_type,
+	.irq_print_chip		= gpio_tsweim_irq_print_chip,
+	.flags			= IRQCHIP_IMMUTABLE,
+	GPIOCHIP_IRQ_RESOURCE_HELPERS,
+};
+
 static const struct of_device_id tsweim_gpio_of_match_table[] = {
 	{ .compatible = "technologic,ts71xxweim-gpio", },
 	{},
@@ -109,6 +272,8 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 	struct device *dev = &pdev->dev;
 	struct tsweim_gpio_priv *priv;
 	struct resource *res;
+	struct gpio_irq_chip *girq;
+	int irq;
 
 	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
 	if (!priv)
@@ -127,7 +292,34 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 	priv->gpio_chip.ngpio = TSWEIM_NR_DIO;
 	priv->gpio_chip.parent = dev;
 
-	return devm_gpiochip_add_data(&pdev->dev, &priv->gpio_chip, &priv);
+	spin_lock_init(&priv->lock);
+
+	irq = platform_get_irq_optional(pdev, 0);
+	if (irq < 0) {
+		return devm_gpiochip_add_data(dev, &priv->gpio_chip, priv);
+	}
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 1);
+	if (!res)
+		return -EFAULT;
+
+	priv->irqbase = devm_ioremap(dev, res->start, resource_size(res));
+	if (!priv->irqbase)
+		return -ENOMEM;
+
+	girq = &priv->gpio_chip.irq;
+	gpio_irq_chip_set_chip(girq, &tsweim_irq_chip);
+	girq->parent_handler = gpio_tsweim_irq_handler;
+	girq->num_parents = 1;
+	girq->parents = devm_kcalloc(dev, 1, sizeof(*girq->parents),
+				     GFP_KERNEL);
+	if (!girq->parents)
+		return -ENOMEM;
+	girq->default_type = IRQ_TYPE_NONE;
+	girq->handler = handle_bad_irq;
+	girq->parents[0] = irq;
+
+	return devm_gpiochip_add_data(dev, &priv->gpio_chip, priv);
 }
 
 static struct platform_driver tsweim_gpio_driver = {

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -111,6 +111,10 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 	void __iomem  *membase;
 	struct resource *res;
 
+	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	if (res == NULL)
 		return -EFAULT;
@@ -120,9 +124,6 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 	if (IS_ERR(membase))
 		return -ENOMEM;
 
-	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
-	if (!priv)
-		return -ENOMEM;
 
 	priv->syscon = membase;
 

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -5,6 +5,7 @@
  */
 
 #include <linux/gpio/driver.h>
+#include <linux/of_address.h>
 #include <linux/of_device.h>
 #include <linux/of_irq.h>
 #include <linux/interrupt.h>
@@ -33,7 +34,13 @@
 #define TSWEIM_GPIO_IRQ_MASK		0xA
 #define TSWEIM_GPIO_IRQ_PENDING		0xC
 
+#define TSWEIM_IRQ_ACK_MODE	0x2C
+#define TSWEIM_IRQ_ACK_MODE_EN	BIT(0)
+
+#define TSWEIM_IRQ_SUPPORTED_FPGA_REV 70
+
 struct tsweim_gpio_priv {
+	void __iomem *syscon;
 	void __iomem *base;
 	void __iomem *irqbase;
 	struct gpio_chip gpio_chip;
@@ -273,7 +280,10 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 	struct tsweim_gpio_priv *priv;
 	struct resource *res;
 	struct gpio_irq_chip *girq;
-	int irq;
+	struct device_node *syscon_of_node;
+	int irq, ret;
+	bool ack_mode_en;
+	u32 revision;
 
 	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
 	if (!priv)
@@ -294,8 +304,39 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 
 	spin_lock_init(&priv->lock);
 
+	syscon_of_node = of_get_parent(pdev->dev.of_node);
+	if (!syscon_of_node)
+		return -EINVAL;
+
+	ret = of_address_to_resource(syscon_of_node, 0, res);
+	of_node_put(syscon_of_node);
+
+	if (ret)
+		return ret;
+
+	priv->syscon = devm_ioremap(dev, res->start, resource_size(res));
+	if (!priv->syscon)
+		return -ENOMEM;
+
+	revision = readl(priv->syscon) & 0xFF;
+	ack_mode_en = readl(priv->syscon + TSWEIM_IRQ_ACK_MODE) & TSWEIM_IRQ_ACK_MODE_EN;
+
+	if (revision >= TSWEIM_IRQ_SUPPORTED_FPGA_REV && !ack_mode_en) {
+		/* set ack_mode_en if FPGA firmware supports it */
+		writel(TSWEIM_IRQ_ACK_MODE_EN, priv->syscon + TSWEIM_IRQ_ACK_MODE);
+
+		ack_mode_en = readl(priv->syscon + TSWEIM_IRQ_ACK_MODE) & TSWEIM_IRQ_ACK_MODE_EN;
+		if (ack_mode_en) {
+			dev_info(dev, "ACK mode enabled with FPGA rev%u\n",
+				revision);
+		} else {
+			dev_warn(dev, "failed to enable ACK mode with FPGA rev%u\n",
+				revision);
+		}
+	}
+
 	irq = platform_get_irq_optional(pdev, 0);
-	if (irq < 0) {
+	if (irq < 0 || !ack_mode_en) {
 		return devm_gpiochip_add_data(dev, &priv->gpio_chip, priv);
 	}
 

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -114,10 +114,24 @@ static void tsweim_gpio_set(struct gpio_chip *chip, unsigned int offset,
 		writew((1 << offset), priv->base + TSWEIM_CLR_REG);
 }
 
+static int tsweim_gpio_get_direction(struct gpio_chip *chip, unsigned int offset)
+{
+	struct tsweim_gpio_priv *priv = to_gpio_tsweim(chip);
+	u16 en_reg;
+
+	if (!(offset < priv->gpio_chip.ngpio))
+		return -EINVAL;
+
+	en_reg = readw(priv->base + TSWEIM_EN_SET_REG);
+
+	return (en_reg & (1 << offset)) ? GPIO_LINE_DIRECTION_OUT : GPIO_LINE_DIRECTION_IN;
+}
+
 static const struct gpio_chip tsweim_gpio_chip = {
 	.owner			= THIS_MODULE,
 	.direction_input	= tsweim_gpio_direction_input,
 	.direction_output	= tsweim_gpio_direction_output,
+	.get_direction		= tsweim_gpio_get_direction,
 	.get			= tsweim_gpio_get,
 	.set			= tsweim_gpio_set,
 	.base			= -1,

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -130,7 +130,6 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 	priv->gpio_chip.label = dev_name(dev);
 	priv->gpio_chip.ngpio = TSWEIM_NR_DIO;
 	priv->gpio_chip.parent = dev;
-	pdev->dev.platform_data = &priv;
 
 	return devm_gpiochip_add_data(&pdev->dev, &priv->gpio_chip, &priv);
 }

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -88,7 +88,7 @@ static void tsweim_gpio_set(struct gpio_chip *chip, unsigned int offset,
 		writew((1 << offset), priv->syscon + TSWEIM_CLR_REG);
 }
 
-static const struct gpio_chip template_chip = {
+static const struct gpio_chip tsweim_gpio_chip = {
 	.owner			= THIS_MODULE,
 	.direction_input	= tsweim_gpio_direction_input,
 	.direction_output	= tsweim_gpio_direction_output,
@@ -130,7 +130,7 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 
 	priv->syscon = membase;
 
-	priv->gpio_chip = template_chip;
+	priv->gpio_chip = tsweim_gpio_chip;
 	priv->gpio_chip.label = dev_name(dev);
 	priv->gpio_chip.ngpio = TSWEIM_NR_DIO;
 	priv->gpio_chip.parent = dev;

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -108,7 +108,6 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
 	struct tsweim_gpio_priv *priv;
-	void __iomem  *membase;
 	struct resource *res;
 
 	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
@@ -119,13 +118,10 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 	if (res == NULL)
 		return -EFAULT;
 
-	membase =  devm_ioremap(&pdev->dev, res->start,
+	priv->syscon = devm_ioremap(&pdev->dev, res->start,
 					  resource_size(res));
-	if (IS_ERR(membase))
+	if (!priv->syscon)
 		return -ENOMEM;
-
-
-	priv->syscon = membase;
 
 	priv->gpio_chip = tsweim_gpio_chip;
 	priv->gpio_chip.label = dev_name(dev);

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -22,7 +22,7 @@
 #define TSWEIM_EN_CLR_REG	0x06
 
 struct tsweim_gpio_priv {
-	void __iomem  *syscon;
+	void __iomem *base;
 	struct gpio_chip gpio_chip;
 };
 
@@ -39,7 +39,7 @@ static int tsweim_gpio_direction_input(struct gpio_chip *chip,
 	if (!(offset < priv->gpio_chip.ngpio))
 		return -EINVAL;
 
-	writew((1 << offset), priv->syscon + TSWEIM_EN_CLR_REG);
+	writew((1 << offset), priv->base + TSWEIM_EN_CLR_REG);
 
 	return 0;
 }
@@ -53,11 +53,11 @@ static int tsweim_gpio_direction_output(struct gpio_chip *chip,
 		return -EINVAL;
 
 	if (value)
-		writew((1 << offset), priv->syscon + TSWEIM_SET_REG);
+		writew((1 << offset), priv->base + TSWEIM_SET_REG);
 	else
-		writew((1 << offset), priv->syscon + TSWEIM_CLR_REG);
+		writew((1 << offset), priv->base + TSWEIM_CLR_REG);
 
-	writew((1 << offset), priv->syscon + TSWEIM_EN_SET_REG);
+	writew((1 << offset), priv->base + TSWEIM_EN_SET_REG);
 
 	return 0;
 }
@@ -70,7 +70,7 @@ static int tsweim_gpio_get(struct gpio_chip *chip, unsigned int offset)
 	if (!(offset < priv->gpio_chip.ngpio))
 		return -EINVAL;
 
-	reg = readw(priv->syscon + TSWEIM_GET_REG);
+	reg = readw(priv->base + TSWEIM_GET_REG);
 	return !!(reg & (1 << offset));
 }
 
@@ -83,9 +83,9 @@ static void tsweim_gpio_set(struct gpio_chip *chip, unsigned int offset,
 		return;
 
 	if (value)
-		writew((1 << offset), priv->syscon + TSWEIM_SET_REG);
+		writew((1 << offset), priv->base + TSWEIM_SET_REG);
 	else
-		writew((1 << offset), priv->syscon + TSWEIM_CLR_REG);
+		writew((1 << offset), priv->base + TSWEIM_CLR_REG);
 }
 
 static const struct gpio_chip tsweim_gpio_chip = {
@@ -118,9 +118,8 @@ static int tsweim_gpio_probe(struct platform_device *pdev)
 	if (res == NULL)
 		return -EFAULT;
 
-	priv->syscon = devm_ioremap(&pdev->dev, res->start,
-					  resource_size(res));
-	if (!priv->syscon)
+	priv->base = devm_ioremap(dev, res->start, resource_size(res));
+	if (!priv->base)
 		return -ENOMEM;
 
 	priv->gpio_chip = tsweim_gpio_chip;

--- a/drivers/gpio/gpio-ts71xxweim.c
+++ b/drivers/gpio/gpio-ts71xxweim.c
@@ -145,13 +145,14 @@ static void gpio_tsweim_irq_handler(struct irq_desc *desc)
 static void gpio_tsweim_irq_ack(struct irq_data *d)
 {
 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	irq_hw_number_t hwirq = irqd_to_hwirq(d);
 	struct tsweim_gpio_priv *priv = gpiochip_get_data(gc);
 	unsigned long flags;
 	u16 reg;
 
 	spin_lock_irqsave(&priv->lock, flags);
 
-	reg = readw(priv->irqbase + TSWEIM_GPIO_IRQ_ACK) | BIT(irqd_to_hwirq(d));
+	reg = readw(priv->irqbase + TSWEIM_GPIO_IRQ_ACK) | BIT(hwirq);
 	writew(reg, priv->irqbase + TSWEIM_GPIO_IRQ_ACK);
 
 	spin_unlock_irqrestore(&priv->lock, flags);
@@ -160,23 +161,25 @@ static void gpio_tsweim_irq_ack(struct irq_data *d)
 static void gpio_tsweim_irq_mask(struct irq_data *d)
 {
 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	irq_hw_number_t hwirq = irqd_to_hwirq(d);
 	struct tsweim_gpio_priv *priv = gpiochip_get_data(gc);
 	unsigned long flags;
 	u16 mask;
 
 	spin_lock_irqsave(&priv->lock, flags);
 
-	mask = readw(priv->irqbase + TSWEIM_GPIO_IRQ_MASK) | BIT(irqd_to_hwirq(d));
+	mask = readw(priv->irqbase + TSWEIM_GPIO_IRQ_MASK) | BIT(hwirq);
 	writew(mask, priv->irqbase + TSWEIM_GPIO_IRQ_MASK);
 
 	spin_unlock_irqrestore(&priv->lock, flags);
 
-	gpiochip_disable_irq(gc, d->hwirq);
+	gpiochip_disable_irq(gc, hwirq);
 }
 
 static void gpio_tsweim_irq_unmask(struct irq_data *d)
 {
 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	irq_hw_number_t hwirq = irqd_to_hwirq(d);
 	struct tsweim_gpio_priv *priv = gpiochip_get_data(gc);
 	unsigned long flags;
 	u16 mask;
@@ -185,7 +188,7 @@ static void gpio_tsweim_irq_unmask(struct irq_data *d)
 
 	spin_lock_irqsave(&priv->lock, flags);
 
-	mask = readw(priv->irqbase + TSWEIM_GPIO_IRQ_MASK) & ~BIT(irqd_to_hwirq(d));
+	mask = readw(priv->irqbase + TSWEIM_GPIO_IRQ_MASK) & ~BIT(hwirq);
 	writew(mask, priv->irqbase + TSWEIM_GPIO_IRQ_MASK);
 
 	spin_unlock_irqrestore(&priv->lock, flags);
@@ -195,7 +198,7 @@ static int gpio_tsweim_irq_set_type(struct irq_data *d, unsigned int type)
 {
 	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
 	struct tsweim_gpio_priv *priv = gpiochip_get_data(gc);
-	unsigned int hwirq = irqd_to_hwirq(d);
+	irq_hw_number_t hwirq = irqd_to_hwirq(d);
 	u16 polarity, edge, edge_sel;
 	unsigned long flags;
 

--- a/drivers/irqchip/irq-ts71xxweim.c
+++ b/drivers/irqchip/irq-ts71xxweim.c
@@ -9,8 +9,11 @@
 #include <linux/of_device.h>
 #include <linux/seq_file.h>
 
+#define TSWEIM_IRQ_ACK		0x20
 #define TSWEIM_IRQ_STATUS	0x24
 #define TSWEIM_IRQ_POLARITY	0x28
+#define TSWEIM_IRQ_ACK_MODE	0x2C
+#define TSWEIM_IRQ_ACK_MODE_EN	BIT(0)
 #define TSWEIM_IRQ_MASK		0x48
 #define TSWEIM_NUM_FPGA_IRQ	32
 
@@ -20,6 +23,7 @@ struct tsweim_intc {
 	struct platform_device *pdev;
 	raw_spinlock_t lock;
 	u32 mask;
+	bool ack_mode_en;
 };
 
 static void tsweim_intc_mask(struct irq_data *d)
@@ -51,6 +55,35 @@ static void tsweim_intc_print_chip(struct irq_data *d, struct seq_file *p)
 	struct tsweim_intc *priv = irq_data_get_irq_chip_data(d);
 
 	seq_printf(p, "%s", dev_name(&priv->pdev->dev));
+}
+
+static void tsweim_intc_irq_ack(struct irq_data *d)
+{
+	struct tsweim_intc *priv = irq_data_get_irq_chip_data(d);
+
+	if (priv->ack_mode_en) {
+		writel(BIT(d->hwirq), priv->syscon + TSWEIM_IRQ_ACK);
+	} else {
+		readl(priv->syscon + TSWEIM_IRQ_STATUS);
+	}
+}
+
+static void tsweim_intc_irq_mask_ack(struct irq_data *d)
+{
+	struct tsweim_intc *priv = irq_data_get_irq_chip_data(d);
+
+	raw_spin_lock(&priv->lock);
+
+	priv->mask = readl(priv->syscon + TSWEIM_IRQ_MASK) & ~BIT(d->hwirq);
+	writel(priv->mask, priv->syscon + TSWEIM_IRQ_MASK);
+
+	raw_spin_unlock(&priv->lock);
+
+	if (priv->ack_mode_en) {
+		writel(BIT(d->hwirq), priv->syscon + TSWEIM_IRQ_ACK);
+	} else {
+		readl(priv->syscon + TSWEIM_IRQ_STATUS);
+	}
 }
 
 static int tsweim_intc_set_type(struct irq_data *d, unsigned int flow_type)
@@ -86,6 +119,8 @@ static struct irq_chip tsweim_intc_chip = {
 	.irq_mask	= tsweim_intc_mask,
 	.irq_unmask	= tsweim_intc_unmask,
 	.irq_print_chip	= tsweim_intc_print_chip,
+	.irq_ack	= tsweim_intc_irq_ack,
+	.irq_mask_ack	= tsweim_intc_irq_mask_ack,
 };
 
 static void tsweim_irq_handler(struct irq_desc *desc)
@@ -132,6 +167,8 @@ static int tsweim_intc_probe(struct platform_device *pdev)
 	struct device *dev = &pdev->dev;
 	struct tsweim_intc *priv;
 	int irq = 0;
+	bool ack_mode_en;
+	u32 revision;
 
 	irq = platform_get_irq(pdev, 0);
 	if (irq < 0)
@@ -168,6 +205,23 @@ static int tsweim_intc_probe(struct platform_device *pdev)
 	irq_set_chained_handler_and_data(irq, tsweim_irq_handler, priv);
 
 	platform_set_drvdata(pdev, priv);
+
+	revision = readl(priv->syscon) & 0xFF;
+	ack_mode_en = readl(priv->syscon + TSWEIM_IRQ_ACK_MODE) & TSWEIM_IRQ_ACK_MODE_EN;
+
+	if (revision >= 65 && !ack_mode_en) {
+		writel(TSWEIM_IRQ_ACK_MODE_EN, priv->syscon + TSWEIM_IRQ_ACK_MODE);
+
+		ack_mode_en = readl(priv->syscon + TSWEIM_IRQ_ACK_MODE) & TSWEIM_IRQ_ACK_MODE_EN;
+		if (ack_mode_en) {
+			dev_info(dev, "ACK mode enabled with FPGA rev%u\n",
+				revision);
+			priv->ack_mode_en = true;
+		} else {
+			dev_warn(dev, "failed to enable ACK mode with FPGA rev%u\n",
+				revision);
+		}
+	}
 
 	return 0;
 }

--- a/drivers/irqchip/irq-ts71xxweim.c
+++ b/drivers/irqchip/irq-ts71xxweim.c
@@ -18,6 +18,7 @@ struct tsweim_intc {
 	void __iomem  *syscon;
 	struct irq_domain *irqdomain;
 	struct platform_device *pdev;
+	raw_spinlock_t lock;
 	u32 mask;
 };
 
@@ -25,16 +26,24 @@ static void tsweim_intc_mask(struct irq_data *d)
 {
 	struct tsweim_intc *priv = irq_data_get_irq_chip_data(d);
 
+	raw_spin_lock(&priv->lock);
+
 	priv->mask = readl(priv->syscon + TSWEIM_IRQ_MASK) & ~BIT(d->hwirq);
 	writel(priv->mask, priv->syscon + TSWEIM_IRQ_MASK);
+
+	raw_spin_unlock(&priv->lock);
 }
 
 static void tsweim_intc_unmask(struct irq_data *d)
 {
 	struct tsweim_intc *priv = irq_data_get_irq_chip_data(d);
 
+	raw_spin_lock(&priv->lock);
+
 	priv->mask = readl(priv->syscon + TSWEIM_IRQ_MASK) | BIT(d->hwirq);
 	writel(priv->mask, priv->syscon + TSWEIM_IRQ_MASK);
+
+	raw_spin_unlock(&priv->lock);
 }
 
 static void tsweim_intc_print_chip(struct irq_data *d, struct seq_file *p)
@@ -47,8 +56,12 @@ static void tsweim_intc_print_chip(struct irq_data *d, struct seq_file *p)
 static int tsweim_intc_set_type(struct irq_data *d, unsigned int flow_type)
 {
 	struct tsweim_intc *priv = irq_data_get_irq_chip_data(d);
-	uint32_t polarity = readl(priv->syscon + TSWEIM_IRQ_POLARITY);
-	uint32_t bit = BIT_MASK(d->hwirq);
+	u32 polarity, bit;
+
+	raw_spin_lock(&priv->lock);
+
+	polarity = readl(priv->syscon + TSWEIM_IRQ_POLARITY);
+	bit = BIT(d->hwirq);
 
 	switch (flow_type) {
 	case IRQ_TYPE_LEVEL_LOW:
@@ -58,10 +71,13 @@ static int tsweim_intc_set_type(struct irq_data *d, unsigned int flow_type)
 		polarity &= ~bit;
 		break;
 	default:
+		raw_spin_unlock(&priv->lock);
 		return -EINVAL;
 	}
 
 	writel(polarity, priv->syscon + TSWEIM_IRQ_POLARITY);
+
+	raw_spin_unlock(&priv->lock);
 
 	return 0;
 }
@@ -130,6 +146,8 @@ static int tsweim_intc_probe(struct platform_device *pdev)
 		return PTR_ERR(priv->syscon);
 
 	priv->pdev = pdev;
+
+	raw_spin_lock_init(&priv->lock);
 
 	if (of_property_read_bool(dev->of_node, "ts,haspolarity"))
 		tsweim_intc_chip.irq_set_type = tsweim_intc_set_type;

--- a/drivers/irqchip/irq-ts71xxweim.c
+++ b/drivers/irqchip/irq-ts71xxweim.c
@@ -186,6 +186,8 @@ static int tsweim_intc_probe(struct platform_device *pdev)
 
 	raw_spin_lock_init(&priv->lock);
 
+	priv->mask = readl(priv->syscon + TSWEIM_IRQ_MASK);
+
 	if (of_property_read_bool(dev->of_node, "ts,haspolarity"))
 		tsweim_intc_chip.irq_set_type = tsweim_intc_set_type;
 

--- a/drivers/irqchip/irq-ts71xxweim.c
+++ b/drivers/irqchip/irq-ts71xxweim.c
@@ -230,7 +230,7 @@ static int tsweim_intc_probe(struct platform_device *pdev)
 
 static int tsweim_intc_remove(struct platform_device *pdev)
 {
-	struct tsweim_intc *priv = dev_get_platdata(&pdev->dev);
+	struct tsweim_intc *priv = platform_get_drvdata(pdev);
 
 	if (priv->irqdomain) {
 		int i, irq;

--- a/drivers/irqchip/irq-ts71xxweim.c
+++ b/drivers/irqchip/irq-ts71xxweim.c
@@ -17,6 +17,8 @@
 #define TSWEIM_IRQ_MASK		0x48
 #define TSWEIM_NUM_FPGA_IRQ	32
 
+#define TSWEIM_IRQ_SUPPORTED_FPGA_REV 70
+
 struct tsweim_intc {
 	void __iomem  *syscon;
 	struct irq_domain *irqdomain;
@@ -211,7 +213,7 @@ static int tsweim_intc_probe(struct platform_device *pdev)
 	revision = readl(priv->syscon) & 0xFF;
 	ack_mode_en = readl(priv->syscon + TSWEIM_IRQ_ACK_MODE) & TSWEIM_IRQ_ACK_MODE_EN;
 
-	if (revision >= 65 && !ack_mode_en) {
+	if (revision >= TSWEIM_IRQ_SUPPORTED_FPGA_REV && !ack_mode_en) {
 		writel(TSWEIM_IRQ_ACK_MODE_EN, priv->syscon + TSWEIM_IRQ_ACK_MODE);
 
 		ack_mode_en = readl(priv->syscon + TSWEIM_IRQ_ACK_MODE) & TSWEIM_IRQ_ACK_MODE_EN;

--- a/drivers/irqchip/irq-ts71xxweim.c
+++ b/drivers/irqchip/irq-ts71xxweim.c
@@ -129,20 +129,19 @@ static void tsweim_irq_handler(struct irq_desc *desc)
 {
 	struct irq_chip *chip = irq_desc_get_chip(desc);
 	struct tsweim_intc *priv = irq_desc_get_handler_data(desc);
-	unsigned int irq;
-	unsigned int status;
+	unsigned long irq, status;
 
 	chained_irq_enter(chip, desc);
 
-	while ((status =
-	  (priv->mask & readl(priv->syscon + TSWEIM_IRQ_STATUS)))) {
-		irq = 0;
-		do {
-			if (status & 1)
-				generic_handle_domain_irq(priv->irqdomain, irq);
-			status >>= 1;
-			irq++;
-		} while (status);
+	status = readl(priv->syscon + TSWEIM_IRQ_STATUS);
+
+	/* before the ack mode functionality the mask was not applied in hardware
+	 * requiring the mask to be applied in software */
+	if (!priv->ack_mode_en)
+		status &= priv->mask;
+
+	for_each_set_bit(irq, &status, TSWEIM_NUM_FPGA_IRQ) {
+		generic_handle_domain_irq(priv->irqdomain, irq);
 	}
 
 	chained_irq_exit(chip, desc);


### PR DESCRIPTION
# irq-ts71xxweim changes

Changes made:
- add ack and mask_ack functions
- add spinlocks for read-modify-write transactions
- add initialisation of priv->mask to value of mask register
- simplified irq handler
- minor fixes

These commits have been tested on a ts7250 v3 with FPGA firmware rev70 by jumping the RX and TX pins together for the three RS-232 UARTS and running them all at 115200 baud for a period of time:
- ttyS8 on the DB9 connector
- ttyS9 on COM2 header
- ttyS10 on COM3 header

The output of linux-serial-test for each tty:
```
/dev/ttyS10: count for this session: rx=3919758, tx=3919814, rx err=0
/dev/ttyS10: TIOCGICOUNT: ret=0, rx=3997939, tx=3997939, frame = 0, overrun = 0, parity = 0, brk = 0, buf_overrun = 0
/dev/ttyS8: count for this session: rx=3923653, tx=3923653, rx err=0
/dev/ttyS8: TIOCGICOUNT: ret=0, rx=4009904, tx=4009904, frame = 0, overrun = 0, parity = 0, brk = 0, buf_overrun = 0
/dev/ttyS9: count for this session: rx=3929020, tx=3932100, rx err=0
/dev/ttyS9: TIOCGICOUNT: ret=0, rx=4018415, tx=4018415, frame = 0, overrun = 0, parity = 0, brk = 0, buf_overrun = 0
```

# gpio-ts71xxweim changes

Changes made:
- add optional IRQ support
- add get_direction function
- minor misc fixes

These commits have been tested on a ts7250 v3 with FPGA firmware rev70 by jumping two gpios together then using gpiomon on one to listen for interrupts and gpioset on the other to trigger interrupts.