### PR TITLE
Input: ads7846: fix buffer overrun on clearing command reg

### DIFF
--- a/drivers/input/touchscreen/ads7846.c
+++ b/drivers/input/touchscreen/ads7846.c
@@ -408,7 +408,6 @@ static int ads7846_read12_ser(struct device *dev, unsigned command)
 	spi_message_add_tail(&req->xfer[5], &req->msg);
 
 	/* clear the command register */
-	req->xfer[6].rx_buf = &req->scratch;
 	req->xfer[6].len = 3;
 	CS_CHANGE(req->xfer[6]);
 	spi_message_add_tail(&req->xfer[6], &req->msg);


### PR DESCRIPTION
The previous patch introduced an overflow of scratch on the rx_buf path by reading 3 bytes in to while while scratch is a u16. This shouldn't actually be an issue due to struct alignment, but, the data returned by the command isn't needed anyway so just use NULL on the rx_buf as well.

Fixes: c5257f511bcfd ("Input: ads7846 - don't use scratch for tx_buf when clearing register (#301)")