### PR TITLE
ARM: dts: imx28-ts7680: Remove i2c0 node

### DIFF
--- a/arch/arm/boot/dts/nxp/mxs/imx28-ts7680.dts
+++ b/arch/arm/boot/dts/nxp/mxs/imx28-ts7680.dts
@@ -312,13 +312,6 @@
 		"HD4_21";
 };
 
-&i2c0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&i2c0_pins_a>;
-	clock-frequency = <100000>;
-	status = "okay";
-};
-
 &lradc {
 	status = "okay";
 };


### PR DESCRIPTION
This i2c0 device was meant to be removed and replaced with i2c-gpio which both request the same pins. The i2c-gpio driver was winning and working, but still should not be loading the unused mxs-i2c driver conflicting on these pins. Remove this conflicting node.