### PR TITLE
6.6: wifi: mac80211: align control-port TX skbs

### DIFF
--- a/net/mac80211/tx.c
+++ b/net/mac80211/tx.c
@@ -6160,8 +6160,8 @@ int ieee80211_tx_control_port(struct wiphy *wiphy, struct net_device *dev,
 
 	flags |= IEEE80211_TX_INTFL_NL80211_FRAME_TX;
 
-	skb = dev_alloc_skb(local->hw.extra_tx_headroom +
-			    sizeof(struct ethhdr) + len);
+	skb = netdev_alloc_skb_ip_align(dev, local->hw.extra_tx_headroom +
+					 sizeof(struct ethhdr) + len);
 	if (!skb)
 		return -ENOMEM;
 


### PR DESCRIPTION
Align NL80211 control-port TX skbs with normal netdev TX allocation. This restores WPA2 EAPOL transmission for QCA9377 ath10k_sdio when modern wpa_supplicant uses NL80211_CMD_CONTROL_PORT_FRAME.